### PR TITLE
Feature/Url session engine

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3723278E22815FF00008BACC /* RestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3723278622815FF00008BACC /* RestClient.swift */; };
 		3723278F22815FF00008BACC /* Host.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3723278722815FF00008BACC /* Host.swift */; };
 		372327912281602F0008BACC /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372327902281602F0008BACC /* HTTPMethod.swift */; };
+		37232797228172050008BACC /* URLSessionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37232796228172050008BACC /* URLSessionEngine.swift */; };
 		37330A9C21BFB0C400AE0BC8 /* StartupProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37330A9921BFB0BF00AE0BC8 /* StartupProcess.swift */; };
 		37330A9D21BFB0C800AE0BC8 /* StartupProcessService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37330A9821BFB0BE00AE0BC8 /* StartupProcessService.swift */; };
 		37330AA221BFBB1D00AE0BC8 /* Broadcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37330AA121BFBB1D00AE0BC8 /* Broadcast.swift */; };
@@ -67,6 +68,7 @@
 		3723278622815FF00008BACC /* RestClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestClient.swift; sourceTree = "<group>"; };
 		3723278722815FF00008BACC /* Host.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Host.swift; sourceTree = "<group>"; };
 		372327902281602F0008BACC /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		37232796228172050008BACC /* URLSessionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionEngine.swift; sourceTree = "<group>"; };
 		37330A9821BFB0BE00AE0BC8 /* StartupProcessService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartupProcessService.swift; sourceTree = "<group>"; };
 		37330A9921BFB0BF00AE0BC8 /* StartupProcess.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartupProcess.swift; sourceTree = "<group>"; };
 		37330A9E21BFB57400AE0BC8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 		3723275C22815EE10008BACC /* RestClient */ = {
 			isa = PBXGroup;
 			children = (
+				37232794228171EE0008BACC /* Engine */,
 				3723277F22815FF00008BACC /* Core */,
 			);
 			path = RestClient;
@@ -214,6 +217,22 @@
 				3723278422815FF00008BACC /* DataResponse.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		37232794228171EE0008BACC /* Engine */ = {
+			isa = PBXGroup;
+			children = (
+				37232795228171F70008BACC /* URLSession */,
+			);
+			path = Engine;
+			sourceTree = "<group>";
+		};
+		37232795228171F70008BACC /* URLSession */ = {
+			isa = PBXGroup;
+			children = (
+				37232796228172050008BACC /* URLSessionEngine.swift */,
+			);
+			path = URLSession;
 			sourceTree = "<group>";
 		};
 		37330A9521BFB06E00AE0BC8 /* Extensions */ = {
@@ -500,6 +519,7 @@
 				37DC7C3221C3BC8800AAC6CC /* String+Povio.swift in Sources */,
 				37330A9C21BFB0C400AE0BC8 /* StartupProcess.swift in Sources */,
 				3723278922815FF00008BACC /* Authentication.swift in Sources */,
+				37232797228172050008BACC /* URLSessionEngine.swift in Sources */,
 				37DC7C0B21C3B64300AAC6CC /* GradientView.swift in Sources */,
 				3723278F22815FF00008BACC /* Host.swift in Sources */,
 				0249B7291F6502FAFD02095B023F4937 /* PovioKit-dummy.m in Sources */,

--- a/PovioKit.podspec
+++ b/PovioKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PovioKit'
-  s.version          = '0.2.2.2'
+  s.version          = '0.2.2.3'
   s.summary          = 'Modular cocoapods libraries collection.'
   s.swift_version    = '5.0'
 
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '11.0'
   s.source_files = 'PovioKit/Classes/**/*.swift'
   s.frameworks = 'UIKit', 'Foundation'
+  s.default_subspecs = 'Utilities', 'Extensions', 'Views', 'Networking/RestClient/URLSession'
 
   s.subspec 'Utilities' do |us|
     us.source_files = 'PovioKit/Classes/Utilities/**/*'
@@ -71,6 +72,11 @@ Pod::Spec.new do |s|
       
       cs.subspec 'Core' do |es|
         es.source_files = 'PovioKit/Classes/Networking/RestClient/Core/*'
+      end
+      
+      cs.subspec 'URLSession' do |es|
+        es.source_files = 'PovioKit/Classes/Networking/RestClient/Engine/URLSession/*'
+        es.dependency 'PovioKit/Networking/RestClient/Core'
       end
     end
   end

--- a/PovioKit.podspec
+++ b/PovioKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PovioKit'
-  s.version          = '0.2.2.3'
+  s.version          = '0.2.2.4'
   s.summary          = 'Modular cocoapods libraries collection.'
   s.swift_version    = '5.0'
 

--- a/PovioKit/Classes/Networking/RestClient/Core/Model/HTTPMethod.swift
+++ b/PovioKit/Classes/Networking/RestClient/Core/Model/HTTPMethod.swift
@@ -3,6 +3,7 @@
 //  PovioKit
 //
 //  Created by Toni Kocjan on 07/05/2019.
+//  Copyright © 2019 Povio Labs. All rights reserved.
 //
 
 import Foundation

--- a/PovioKit/Classes/Networking/RestClient/Engine/URLSession/URLSessionEngine.swift
+++ b/PovioKit/Classes/Networking/RestClient/Engine/URLSession/URLSessionEngine.swift
@@ -1,0 +1,45 @@
+//
+//  URLSessionEngine.swift
+//  PovioKit
+//
+//  Created by Toni Kocjan on 07/05/2019.
+//  Copyright © 2019 Povio Labs. All rights reserved.
+//
+
+import Foundation
+
+public class URLSessionRequestEngine<Error: NetworkErrorProtocol>: RequestEngine {
+  public func request(endpoint: EndpointProtocol, method: HTTPMethod, parameters: [String : Any]?, headers: [String : String]?, _ result: ((Result<DataResponse, Error>) -> Void)?) {
+    guard let url = URL(string: endpoint.path) else {
+      result?(.failure(Error(invalidUrl: endpoint.path)))
+      return
+    }
+    let body: Data?
+    if let parameters = parameters {
+      guard let data = try? JSONSerialization.data(withJSONObject: parameters, options: []) else {
+        result?(.failure(.encoding))
+        return
+      }
+      body = data
+    } else {
+      body = nil
+    }
+    
+    var request = URLRequest(url: url)
+    request.httpMethod = method.rawValue
+    request.httpBody = body
+    request.allHTTPHeaderFields = headers
+    
+    URLSession.shared.dataTask(with: request) { data, response, error in
+      switch (data, response, error) {
+      case let (.some(data), .some(response), .none):
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 200
+        result?(.success(DataResponse(statusCode: statusCode, data: data)))
+      case let (_, _, .some(error)):
+        result?(.failure(Error(error)))
+      default:
+        break
+      }
+      }.resume()
+  }
+}

--- a/PovioKit/Classes/Networking/RestClient/Engine/URLSession/URLSessionEngine.swift
+++ b/PovioKit/Classes/Networking/RestClient/Engine/URLSession/URLSessionEngine.swift
@@ -9,6 +9,8 @@
 import Foundation
 
 public class URLSessionRequestEngine<Error: NetworkErrorProtocol>: RequestEngine {
+  public init() {}
+  
   public func request(endpoint: EndpointProtocol, method: HTTPMethod, parameters: [String : Any]?, headers: [String : String]?, _ result: ((Result<DataResponse, Error>) -> Void)?) {
     guard let url = URL(string: endpoint.path) else {
       result?(.failure(Error(invalidUrl: endpoint.path)))


### PR DESCRIPTION
Implemented a simple `URLSession` request engine.
Example usage:

```Swift
enum NetworkError: NetworkErrorProtocol {
  case encodingError
  case decodingError
  case invalidUrl(String)
  case wrapped(Error)
  
  init(invalidUrl url: String) {
    self = .invalidUrl(url)
  }
  
  init(_ error: Error) {
    self = .wrapped(error)
  }
  
  static var decoding: NetworkError { return .decodingError }
  static var encoding: NetworkError { return .encodingError }
}

...

let restClient = RestClient(requestEngine: URLSessionRequestEngine<NetworkError>())

...

restClient.GET(endpoint: .endpoint) { ... }
```