### PR TITLE
Fix/Toggle Promise

### DIFF
--- a/PovioKit/Classes/Utilities/PromiseKit/Future.swift
+++ b/PovioKit/Classes/Utilities/PromiseKit/Future.swift
@@ -11,6 +11,7 @@ import Foundation
 public class Future<Value, Error: Swift.Error> {
   private let dispatchQueue = DispatchQueue(label: "com.poviokit.future", attributes: .concurrent)
   private var observers = [Observer]()
+  public var isEnabled = true
   private var internalResult: FutureResult?
 }
 
@@ -26,6 +27,7 @@ public extension Future {
     set {
       dispatchQueue.async {
         self.internalResult = newValue
+        guard self.isEnabled else { return }
         newValue.map { value in self.observers.forEach { $0.notifity(value) } }
       }
     }


### PR DESCRIPTION
By setting this flag to false, you disable observer triggering. This can, for instance, help with an issue where you have promises on tableView cells and don't want them to trigger on cell reuse (we had such an issue on skip).