### PR TITLE
Register cells using variadic arguments

### DIFF
--- a/Sources/Core/Extensions/UIKit/UICollectionView+Povio.swift
+++ b/Sources/Core/Extensions/UIKit/UICollectionView+Povio.swift
@@ -9,20 +9,20 @@
 import UIKit
 
 public extension UICollectionView {    
-  func register<T: UICollectionViewCell>(_: T.Type) {
-    register(T.self, forCellWithReuseIdentifier: T.identifier)
+  func registerCells<T: UICollectionViewCell>(_ cells: T.Type...) {
+    cells.forEach { register($0.self, forCellWithReuseIdentifier: $0.identifier) }
   }
   
   func registerSupplementaryView<T: UICollectionReusableView>(_: T.Type, kind: String) {
     register(T.self, forSupplementaryViewOfKind: kind, withReuseIdentifier: T.identifier)
   }
   
-  func register<T: UICollectionReusableView>(headerView: T.Type) {
-    registerSupplementaryView(headerView, kind: UICollectionView.elementKindSectionHeader)
+  func registerHeaderViews<T: UICollectionReusableView>(_ headerViews: T.Type...) {
+    headerViews.forEach { registerSupplementaryView($0, kind: UICollectionView.elementKindSectionHeader) }
   }
   
-  func register<T: UICollectionReusableView>(footerView: T.Type) {
-    registerSupplementaryView(footerView, kind: UICollectionView.elementKindSectionFooter)
+  func registerFooterViews<T: UICollectionReusableView>(_ footerViews: T.Type...) {
+    footerViews.forEach { registerSupplementaryView($0, kind: UICollectionView.elementKindSectionFooter) }
   }
   
   func dequeuReusableCell<T: UICollectionViewCell>(at indexPath: IndexPath) -> T {
@@ -66,5 +66,23 @@ public extension UICollectionView {
   var maxContentSize: CGSize {
     .init(width: bounds.width - (contentInset.left + contentInset.right),
           height: bounds.height - (contentInset.top + contentInset.bottom))
+  }
+}
+
+// MARK: - Deprecated
+extension UICollectionView {
+  @available(*, deprecated, renamed: "registerCells")
+  func register<T: UICollectionViewCell>(_: T.Type) {
+    register(T.self, forCellWithReuseIdentifier: T.identifier)
+  }
+  
+  @available(*, deprecated, renamed: "registerHeaderViews")
+  func register<T: UICollectionReusableView>(headerView: T.Type) {
+    registerSupplementaryView(headerView, kind: UICollectionView.elementKindSectionHeader)
+  }
+  
+  @available(*, deprecated, renamed: "registerFooterViews")
+  func register<T: UICollectionReusableView>(footerView: T.Type) {
+    registerSupplementaryView(footerView, kind: UICollectionView.elementKindSectionFooter)
   }
 }

--- a/Sources/Core/Extensions/UIKit/UICollectionView+Povio.swift
+++ b/Sources/Core/Extensions/UIKit/UICollectionView+Povio.swift
@@ -8,20 +8,35 @@
 
 import UIKit
 
-public extension UICollectionView {    
-  func registerCells<T: UICollectionViewCell>(_ cells: T.Type...) {
+public extension UICollectionView {
+  @available(*, deprecated, renamed: "register(_:)")
+  func register<T: UICollectionViewCell>(_: T.Type) {
+    register(T.self, forCellWithReuseIdentifier: T.identifier)
+  }
+  
+  @available(*, deprecated, renamed: "registerHeaderViews")
+  func register<T: UICollectionReusableView>(headerView: T.Type) {
+    registerSupplementaryView(headerView, kind: UICollectionView.elementKindSectionHeader)
+  }
+  
+  @available(*, deprecated, renamed: "registerFooterViews")
+  func register<T: UICollectionReusableView>(footerView: T.Type) {
+    registerSupplementaryView(footerView, kind: UICollectionView.elementKindSectionFooter)
+  }
+  
+  func register(_ cells: UICollectionViewCell.Type...) {
     cells.forEach { register($0.self, forCellWithReuseIdentifier: $0.identifier) }
   }
   
-  func registerSupplementaryView<T: UICollectionReusableView>(_: T.Type, kind: String) {
-    register(T.self, forSupplementaryViewOfKind: kind, withReuseIdentifier: T.identifier)
+  func registerSupplementaryView(_ view: UICollectionReusableView.Type, kind: String) {
+    register(view.self, forSupplementaryViewOfKind: kind, withReuseIdentifier: view.identifier)
   }
   
-  func registerHeaderViews<T: UICollectionReusableView>(_ headerViews: T.Type...) {
+  func registerHeaderViews(_ headerViews: UICollectionReusableView.Type...) {
     headerViews.forEach { registerSupplementaryView($0, kind: UICollectionView.elementKindSectionHeader) }
   }
   
-  func registerFooterViews<T: UICollectionReusableView>(_ footerViews: T.Type...) {
+  func registerFooterViews(_ footerViews: UICollectionReusableView.Type...) {
     footerViews.forEach { registerSupplementaryView($0, kind: UICollectionView.elementKindSectionFooter) }
   }
   
@@ -66,23 +81,5 @@ public extension UICollectionView {
   var maxContentSize: CGSize {
     .init(width: bounds.width - (contentInset.left + contentInset.right),
           height: bounds.height - (contentInset.top + contentInset.bottom))
-  }
-}
-
-// MARK: - Deprecated
-extension UICollectionView {
-  @available(*, deprecated, renamed: "registerCells")
-  func register<T: UICollectionViewCell>(_: T.Type) {
-    register(T.self, forCellWithReuseIdentifier: T.identifier)
-  }
-  
-  @available(*, deprecated, renamed: "registerHeaderViews")
-  func register<T: UICollectionReusableView>(headerView: T.Type) {
-    registerSupplementaryView(headerView, kind: UICollectionView.elementKindSectionHeader)
-  }
-  
-  @available(*, deprecated, renamed: "registerFooterViews")
-  func register<T: UICollectionReusableView>(footerView: T.Type) {
-    registerSupplementaryView(footerView, kind: UICollectionView.elementKindSectionFooter)
   }
 }

--- a/Sources/Core/Extensions/UIKit/UITableView+Povio.swift
+++ b/Sources/Core/Extensions/UIKit/UITableView+Povio.swift
@@ -9,12 +9,12 @@
 import UIKit
 
 public extension UITableView {
-  func register<T: UITableViewCell>(cell: T.Type) {
-    register(T.self, forCellReuseIdentifier: T.identifier)
+  func registerCells<T: UITableViewCell>(_ cells: T.Type...) {
+    cells.forEach { register($0.self, forCellReuseIdentifier: $0.identifier) }
   }
   
-  func register<T: UITableViewHeaderFooterView>(headerFooterView: T.Type) {
-    register(T.self, forHeaderFooterViewReuseIdentifier: T.identifier)
+  func registerHeaderFooterViews<T: UITableViewHeaderFooterView>(_ headerFooterViews: T.Type...) {
+    headerFooterViews.forEach { register($0.self, forHeaderFooterViewReuseIdentifier: $0.identifier) }
   }
   
   func dequeueReusableCell<T: UITableViewCell>(forIndexPath indexPath: IndexPath) -> T {
@@ -64,5 +64,18 @@ public extension UITableView {
     let lastSection = max(0, numberOfSections - 1)
     let lastRow = max(0, numberOfRows(inSection: lastSection) - 1)
     scrollToRow(at: IndexPath(row: lastRow, section: lastSection), at: .bottom, animated: animated)
+  }
+}
+
+// MARK: - Deprecated
+extension UITableView {
+  @available(*, deprecated, renamed: "registerCells")
+  func register<T: UITableViewCell>(cell: T.Type) {
+    register(T.self, forCellReuseIdentifier: T.identifier)
+  }
+  
+  @available(*, deprecated, renamed: "registerHeaderFooterViews")
+  func register<T: UITableViewHeaderFooterView>(headerFooterView: T.Type) {
+    register(T.self, forHeaderFooterViewReuseIdentifier: T.identifier)
   }
 }

--- a/Sources/Core/Extensions/UIKit/UITableView+Povio.swift
+++ b/Sources/Core/Extensions/UIKit/UITableView+Povio.swift
@@ -9,11 +9,21 @@
 import UIKit
 
 public extension UITableView {
-  func registerCells<T: UITableViewCell>(_ cells: T.Type...) {
+  @available(*, deprecated, renamed: "register(_:)")
+  func register<T: UITableViewCell>(cell: T.Type) {
+    register(T.self, forCellReuseIdentifier: T.identifier)
+  }
+  
+  @available(*, deprecated, renamed: "register(_:)")
+  func register<T: UITableViewHeaderFooterView>(headerFooterView: T.Type) {
+    register(T.self, forHeaderFooterViewReuseIdentifier: T.identifier)
+  }
+  
+  func register(_ cells: UITableViewCell.Type...) {
     cells.forEach { register($0.self, forCellReuseIdentifier: $0.identifier) }
   }
   
-  func registerHeaderFooterViews<T: UITableViewHeaderFooterView>(_ headerFooterViews: T.Type...) {
+  func register(_ headerFooterViews: UITableViewHeaderFooterView.Type...) {
     headerFooterViews.forEach { register($0.self, forHeaderFooterViewReuseIdentifier: $0.identifier) }
   }
   
@@ -64,18 +74,5 @@ public extension UITableView {
     let lastSection = max(0, numberOfSections - 1)
     let lastRow = max(0, numberOfRows(inSection: lastSection) - 1)
     scrollToRow(at: IndexPath(row: lastRow, section: lastSection), at: .bottom, animated: animated)
-  }
-}
-
-// MARK: - Deprecated
-extension UITableView {
-  @available(*, deprecated, renamed: "registerCells")
-  func register<T: UITableViewCell>(cell: T.Type) {
-    register(T.self, forCellReuseIdentifier: T.identifier)
-  }
-  
-  @available(*, deprecated, renamed: "registerHeaderFooterViews")
-  func register<T: UITableViewHeaderFooterView>(headerFooterView: T.Type) {
-    register(T.self, forHeaderFooterViewReuseIdentifier: T.identifier)
   }
 }


### PR DESCRIPTION
Current implementation allows you to register only one cell at a time.
This PR makes it possible to pass variadic arguments to the new added methods, registering more than one cell at a time.

Old implementation:

```
tableView.register(cell: ContactsSourceCell.self)
tableView.register(cell: ContactsSyncSourcesCell.self)
```

New implementation:

```
tableView.register(
    ContactsSourceCell.self,
    ContactsSyncSourcesCell.self
 )
```