### PR TITLE
feature/ParameterEncoder as parameter

### DIFF
--- a/Sources/Networking/AlamofireNetworkClient/AlamofireNetworkClient.swift
+++ b/Sources/Networking/AlamofireNetworkClient/AlamofireNetworkClient.swift
@@ -111,6 +111,29 @@ public extension AlamofireNetworkClient {
     return .init(with: request, eventMonitors: eventMonitors)
   }
   
+  func request<E: Encodable>(
+    method: HTTPMethod,
+    endpoint: URLConvertible,
+    headers: HTTPHeaders? = nil,
+    encode: E,
+    parameterEncoder: ParameterEncoder,
+    interceptor: RequestInterceptor? = nil,
+    uploadProgress: ProgressHandler? = nil,
+    downloadProgress: ProgressHandler? = nil
+  ) -> Request {
+    let request = session
+      .request(
+        endpoint,
+        method: method,
+        parameters: encode,
+        encoder: parameterEncoder,
+        headers: headers,
+        interceptor: interceptor)
+    _ = uploadProgress.map { request.uploadProgress(closure: $0) }
+    _ = downloadProgress.map { request.downloadProgress(closure: $0) }
+    return .init(with: request, eventMonitors: eventMonitors)
+  }
+  
   func upload(
     method: HTTPMethod,
     endpoint: URLConvertible,

--- a/Sources/Networking/AlamofireNetworkClient/Extensions/ParameterEncoder+PovioKit.swift
+++ b/Sources/Networking/AlamofireNetworkClient/Extensions/ParameterEncoder+PovioKit.swift
@@ -1,0 +1,25 @@
+//
+//  ParameterEncoder+PovioKit.swift
+//  PovioKit
+//
+//  Created by Egzon Arifi on 20/05/2022.
+//  Copyright © 2022 Povio Inc. All rights reserved.
+//
+
+import Alamofire
+import Foundation
+
+public extension ParameterEncoder where Self == URLEncodedFormParameterEncoder {
+  static func urlEncoder(
+    encoder: JSONEncoder = .init(),
+    arrayEncoding: URLEncodedFormEncoder.ArrayEncoding = .noBrackets
+  ) -> URLEncodedFormParameterEncoder {
+    .init(encoder: encoder, arrayEncoding: arrayEncoding)
+  }
+}
+
+public extension ParameterEncoder where Self == JSONParameterEncoder {
+  static func jsonEncoder(encoder: JSONEncoder = .init()) -> JSONParameterEncoder {
+    .init(encoder: encoder)
+  }
+}

--- a/Sources/UI/Extensions/Image+Povio.swift
+++ b/Sources/UI/Extensions/Image+Povio.swift
@@ -14,6 +14,7 @@ public extension Image {}
 #if canImport(Kingfisher)
 import Kingfisher
 
+@available(iOS 14, *)
 private extension Image {
   func resolveWithKingFisher(from url: URL?, placeholder: Image?) -> some View {
     KFImage(url)


### PR DESCRIPTION
**Current issue:** 
- ANC request method explicitly sends Encodable object as query params on .get, .delete, .head http methods, but we want to easily change that from ANC usage

**Proposal:**
- In order to not break current usage, new method is created and we can pass ParameterEncoder without having to import anything else.

```client
      .request(method: .delete,
               endpoint: Endpoints.conversationParticipants(conversationId),
               encode: request,
               parameterEncoder: .jsonEncoder())
      .validate()
      .defaultFailure()
      .asVoid```
      