### PR TITLE
OAuthInterceptor - Smaller memory footprint

### DIFF
--- a/Sources/Networking/AlamofireNetworkClient/OAuth/OAuthInterceptor.swift
+++ b/Sources/Networking/AlamofireNetworkClient/OAuth/OAuthInterceptor.swift
@@ -29,7 +29,8 @@ open class OAuthRequestInterceptor {
   private let storage: OAuthStorage
   private let adapter: OAuthHeadersAdapter
   private let lock: NSLock = .init()
-  private var activeRequests: [UUID: RequestState] = .init()
+  private var activeRequests: [UUID: RequestState] = .init() /// @TODO: - Design a strategy to clear `activeRequests`
+                                                             /// once in a while ...
   
   public init(
     provider: OAuthProvider,


### PR DESCRIPTION
Instead of storing `Request`, which is a reference type, therefore its memory never gets cleared for the entire lifetime of the app, store `UUID`, which is a value type (hence copied). This change will leave a smaller memory footprint when using `OAuthInterceptor`.