### PR TITLE
OAuthInterceptor - Use Semaphore instead of Lock

### DIFF
--- a/Sources/Networking/AlamofireNetworkClient/OAuth/OAuthInterceptor.swift
+++ b/Sources/Networking/AlamofireNetworkClient/OAuth/OAuthInterceptor.swift
@@ -70,7 +70,7 @@ extension OAuthRequestInterceptor: RequestInterceptor {
   ) {
     switch error.asAFError {
     case .responseValidationFailed(reason: .unacceptableStatusCode(code: 401)):
-      lock.signal()
+      lock.wait(timeout: .distantFuture)
       
       switch activeRequests[request.id] {
       case nil:
@@ -80,7 +80,7 @@ extension OAuthRequestInterceptor: RequestInterceptor {
       case .reject:
         activeRequests.removeValue(forKey: request.id)
         completion(.doNotRetryWithError(error))
-        lock.wait()
+        lock.signal()
         return
       }
       
@@ -91,7 +91,7 @@ extension OAuthRequestInterceptor: RequestInterceptor {
         case .failure(let error):
           completion(.doNotRetryWithError(error))
         }
-        self.lock.wait()
+        self.lock.signal()
       }
     case _:
       completion(.doNotRetryWithError(error))


### PR DESCRIPTION
Replaced `NSLock` with `DispatchSemaphore`, which might help with some issues that are currently present when using `OAuthInterceptor`.

This is an experimental change that needs to be tested in-depth in the projects that use `OAuthInterceptor`.