### PR TITLE
Feature/PromiseKit - Sleep

### DIFF
--- a/Sources/PromiseKit/Promise.swift
+++ b/Sources/PromiseKit/Promise.swift
@@ -107,6 +107,7 @@ public class Promise<Value>: Future<Value, Error> {
   }
 }
 
+// MARK: - States
 public extension Promise {
   var isResolved: Bool {
     result != nil
@@ -153,6 +154,7 @@ public extension Promise {
   }
 }
 
+// MARK: - Utils
 public extension Promise {
   /// Convert this Promise to a new Promise where `Value` == ()
   var asVoid: Promise<()> {
@@ -199,6 +201,7 @@ public extension Promise {
   }
 }
 
+// MARK: - Core
 public extension Promise {
   /// Returns a composition of this Promise with the result of calling `transform`.
   ///

--- a/Sources/PromiseKit/Promise.swift
+++ b/Sources/PromiseKit/Promise.swift
@@ -189,7 +189,7 @@ public extension Promise {
         switch $0 {
         case .success(let value):
           dispatchQueue.asyncAfter(deadline: .now() + duration) {
-            seal.resolve(with: value)
+            seal.resolve(with: value, on: dispatchQueue)
           }
         case .failure(let error):
           dispatchQueue.asyncAfter(deadline: .now() + duration) {

--- a/Sources/PromiseKit/Promise.swift
+++ b/Sources/PromiseKit/Promise.swift
@@ -176,6 +176,27 @@ public extension Promise {
     `catch`(work)
     return self
   }
+  
+  /// Sleep promise execution for given `duration` interval and return new promise with existing value.
+  func sleep(
+    duration: DispatchTimeInterval,
+    on dispatchQueue: DispatchQueue = .main
+  ) -> Promise<Value> {
+    Promise { seal in
+      self.finally {
+        switch $0 {
+        case .success(let value):
+          dispatchQueue.asyncAfter(deadline: .now() + duration) {
+            seal.resolve(with: value)
+          }
+        case .failure(let error):
+          dispatchQueue.asyncAfter(deadline: .now() + duration) {
+            seal.reject(with: error, on: dispatchQueue)
+          }
+        }
+      }
+    }
+  }
 }
 
 public extension Promise {


### PR DESCRIPTION
I got an idea to have a delay after certain promise finishes up without interrupting the flow. So I write up and function that does this for you.

```swift
worker
  .job
  .sleep(duration: .milliseconds(500))
  .finally { ... }
```

Where is this helpful? I got a scenario where pull-to-refresh refreshed "to quickly". Yes, you heard it right. The API that was triggered on pull to refresh returned response before the component was rendered on screen. So adding a delay solved that issue so component had time to render on screen completely.

You would probably argue why handle UI stuff on the business part of the app. I completely feel you and I thought the same way. But after thinking about this issue way too long, I've decided to do it this way. If I would handle this on the UI, I would probably do smth like that:

```swift
DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
  // update UI
}
```

But that's just silly. And doing that for every such task is silly as well. Instead, just delay API response a bit and you are done.

Thoughts?