### PR TITLE
Feature/ci workflow improvement

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -21,7 +21,7 @@ jobs:
         xcode-version: latest-stable
 
     - name: Build project
-      run: set -o pipefail xcodebuild build-for-testing -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package'
+      run: set -o pipefail xcodebuild build-for-testing -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package' | xcpretty
 
     - name: Run tests
-      run: set -o pipefail xcodebuild test-without-building -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package'
+      run: set -o pipefail xcodebuild test-without-building -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package' | xcpretty

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -20,5 +20,8 @@ jobs:
       with:
         xcode-version: latest-stable
 
+    - name: Build project
+      run: xcodebuild build-for-testing -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package'
+
     - name: Run tests
-      run: xcodebuild test -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package'
+      run: xcodebuild test-without-building -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package'

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -21,7 +21,8 @@ jobs:
         xcode-version: latest-stable
 
     - name: Build project
-      run: set -o pipefail xcodebuild build-for-testing -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package' | xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild build-for-testing -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package' | xcpretty
 
     - name: Run tests
-      run: set -o pipefail xcodebuild test-without-building -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package' | xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package' | xcpretty
+      

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -21,7 +21,7 @@ jobs:
         xcode-version: latest-stable
 
     - name: Build project
-      run: xcodebuild build-for-testing -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package'
+      run: set -o pipefail xcodebuild build-for-testing -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package'
 
     - name: Run tests
-      run: xcodebuild test-without-building -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package'
+      run: set -o pipefail xcodebuild test-without-building -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package'

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -20,8 +20,5 @@ jobs:
       with:
         xcode-version: latest-stable
 
-    - name: Generate Project
-      run: swift package generate-xcodeproj
-
     - name: Run tests
       run: xcodebuild test -destination 'name=iPhone 13 Pro' -scheme 'PovioKit-Package'


### PR DESCRIPTION
Recently I had to do some research about CI-related tasks on my project and I found out about some good practices.

I've split the `Generate Project` step into two:

- `build-without-testing`
- `test-without-building`

Now we have one step for building the package and one step for testing the package. This way we can accurately catch if it's failing during build or test time.

I've added  `set -o pipefail` which makes the pipeline use an occurred [error code as the final code](http://redsymbol.net/articles/unofficial-bash-strict-mode/) of the whole pipeline.

One other interesting argument is `xcpretty`. This formats the code keeps it clean thus we can be more focused on what we actually want from the logs.

### Left we have tests with xcpretty, on the right without.
<img width="1538" alt="Screen Shot 2022-07-09 at 10 47 48 AM" src="https://user-images.githubusercontent.com/15278390/179002997-39ce16ea-097f-4b03-bd6f-ea38e173249d.png">

There was a caveat with this approach, since it could happen that xcpretty didn't print out the logs, a fix for this was setting `env NSUnbufferedIO=YES` , basically this allowed for timely feedback. You can find more information  [here](https://nshipster.com/launch-arguments-and-environment-variables/).
