### PR TITLE
Promise/Sequence

### DIFF
--- a/Sources/PromiseKit/ConcurrentDispatch.swift
+++ b/Sources/PromiseKit/ConcurrentDispatch.swift
@@ -43,7 +43,7 @@ public func concurrentlyDispatch<T>(
   retryCount: Int = 2,
   on dispatchQueue: DispatchQueue? = .main
 ) -> Promise<()> {
-  return .init { seal in
+  .init { seal in
     let barrier = DispatchQueue(label: "com.poviokit.promisekit.barrier", attributes: .concurrent)
     
     var segmentIndex = concurrent

--- a/Sources/PromiseKit/ConcurrentDispatch.swift
+++ b/Sources/PromiseKit/ConcurrentDispatch.swift
@@ -32,6 +32,9 @@ import Foundation
 /// )
 /// .finally { print("Upload result: \($0)") }
 ///
+/// In scenarious where only one concurrent task can be executed at once,
+/// using `sequence` is preferable as it is much faster.
+///
 /// - Parameter next: Spawn a task with the given index. Return `nil` if all tasks have been spawn.
 /// - Parameter concurrent: The number of concurrent tasks executing at a given time.
 /// - Parameter retryCount: The number of times a task should be retried in case it fails.

--- a/Sources/PromiseKit/ConcurrentDispatch.swift
+++ b/Sources/PromiseKit/ConcurrentDispatch.swift
@@ -32,7 +32,7 @@ import Foundation
 /// )
 /// .finally { print("Upload result: \($0)") }
 ///
-/// In scenarious where only one concurrent task can be executed at once,
+/// In scenarios where only one concurrent task can be executed at once,
 /// using `sequence` is preferable as it is much faster.
 ///
 /// - Parameter next: Spawn a task with the given index. Return `nil` if all tasks have been spawn.

--- a/Sources/PromiseKit/Promise.swift
+++ b/Sources/PromiseKit/Promise.swift
@@ -222,8 +222,7 @@ public extension Promise {
         case .success(let value):
           dispatchQueue.async {
             do {
-              let promise = try transform(value)
-              promise.finally {
+              try transform(value).finally {
                 switch $0 {
                 case .success(let value):
                   seal.resolve(with: value, on: dispatchQueue)

--- a/Sources/PromiseKit/Sequence.swift
+++ b/Sources/PromiseKit/Sequence.swift
@@ -3,6 +3,7 @@
 //  
 //
 //  Created by Toni K. Turk on 08/08/2022.
+//  Copyright © 2022 Povio Inc. All rights reserved.
 //
 
 import Foundation

--- a/Sources/PromiseKit/Sequence.swift
+++ b/Sources/PromiseKit/Sequence.swift
@@ -1,0 +1,59 @@
+//
+//  Sequence.swift
+//  
+//
+//  Created by Toni K. Turk on 08/08/2022.
+//
+
+import Foundation
+
+public func sequence<T>(
+  spawnTask: @escaping (Int) -> Promise<T>?,
+  retryCount: Int = 2
+) -> Promise<()> {
+  .init { seal in
+    var taskCount = 0
+    var currentRetryCount = 0
+    
+    func observer(_ result: Result<T, Error>) {
+      switch result {
+      case .success:
+        taskCount += 1
+        currentRetryCount = 0
+        guard let promise = spawnTask(taskCount) else {
+          seal.resolve()
+          return
+        }
+        promise.finally(with: observer)
+      case .failure where currentRetryCount < retryCount:
+        currentRetryCount += 1
+        guard let promise = spawnTask(taskCount) else {
+          seal.resolve()
+          return
+        }
+        promise.finally(with: observer)
+      case .failure(let error):
+        seal.reject(with: error)
+      }
+    }
+    
+    guard let promise = spawnTask(taskCount) else {
+      seal.resolve()
+      return
+    }
+    promise.finally(with: observer)
+  }
+}
+
+public typealias Thunk<T> = () -> T
+
+public func sequence<C: Collection, T>(
+  promises: C,
+  retryCount: Int = 2
+) -> Promise<()> where C.Element == Thunk<Promise<T>>, C.Index == Int {
+  func next(_ idx: Int) -> Promise<T>? {
+    guard promises.indices.contains(idx) else { return nil }
+    return promises[idx]()
+  }
+  return sequence(spawnTask: next, retryCount: retryCount)
+}

--- a/Sources/PromiseKit/Sequence.swift
+++ b/Sources/PromiseKit/Sequence.swift
@@ -7,9 +7,23 @@
 
 import Foundation
 
+/// Execute a series of tasks in a sequence. A new task
+/// is spawned once the previous one succeeds. If a task tails,
+/// it can (optionally) be retried for several times, depending on the
+/// `retryCount` parameter's value.
+///
+/// This method does the same job as `concurrentDispatch` with
+/// `concurrent` set to 1. However, it is faster (as there is no overhead
+/// of synchronization) and therefore preferable when only one task has to
+/// be performed at once.
+///
+/// - Parameter next: Spawn a task with the given index. Return `nil` if all tasks have been spawn.
+/// - Parameter retryCount: The number of times a task should be retried in case it fails.
+/// - Parameter dispatchQueue: The DispatchQueue on which the result should be notified.
 public func sequence<T>(
-  spawnTask: @escaping (Int) -> Promise<T>?,
-  retryCount: Int = 2
+  spawnTask next: @escaping (Int) -> Promise<T>?,
+  retryCount: Int = 2,
+  on dispatchQueue: DispatchQueue? = .main
 ) -> Promise<()> {
   .init { seal in
     var taskCount = 0
@@ -20,25 +34,25 @@ public func sequence<T>(
       case .success:
         taskCount += 1
         currentRetryCount = 0
-        guard let promise = spawnTask(taskCount) else {
-          seal.resolve()
+        guard let promise = next(taskCount) else {
+          seal.resolve(on: dispatchQueue)
           return
         }
         promise.finally(with: observer)
       case .failure where currentRetryCount < retryCount:
         currentRetryCount += 1
-        guard let promise = spawnTask(taskCount) else {
-          seal.resolve()
+        guard let promise = next(taskCount) else {
+          seal.resolve(on: dispatchQueue)
           return
         }
         promise.finally(with: observer)
       case .failure(let error):
-        seal.reject(with: error)
+        seal.reject(with: error, on: dispatchQueue)
       }
     }
     
-    guard let promise = spawnTask(taskCount) else {
-      seal.resolve()
+    guard let promise = next(taskCount) else {
+      seal.resolve(on: dispatchQueue)
       return
     }
     promise.finally(with: observer)
@@ -47,13 +61,27 @@ public func sequence<T>(
 
 public typealias Thunk<T> = () -> T
 
+/// Execute a series of tasks in a sequence. A new task
+/// is spawned once the previous one succeeds. If a task tails,
+/// it can (optionally) be retried for several times, depending on the
+/// `retryCount` parameter's value.
+///
+/// This method does the same job as `concurrentDispatch` with
+/// `concurrent` set to 1. However, it is faster (as there is no overhead
+/// of synchronization) and therefore preferable when only one task has to
+/// be performed at once.
+///
+/// - Parameter promises: An ordered collection of (thunked) promises that will be executed one by one.
+/// - Parameter retryCount: The number of times a task should be retried in case it fails.
+/// - Parameter dispatchQueue: The DispatchQueue on which the result should be notified.
 public func sequence<C: Collection, T>(
   promises: C,
-  retryCount: Int = 2
+  retryCount: Int = 2,
+  on dispatchQueue: DispatchQueue? = .main
 ) -> Promise<()> where C.Element == Thunk<Promise<T>>, C.Index == Int {
   func next(_ idx: Int) -> Promise<T>? {
     guard promises.indices.contains(idx) else { return nil }
     return promises[idx]()
   }
-  return sequence(spawnTask: next, retryCount: retryCount)
+  return sequence(spawnTask: next, retryCount: retryCount, on: dispatchQueue)
 }

--- a/Tests/Tests/PromiseKit/PromiseTests.swift
+++ b/Tests/Tests/PromiseKit/PromiseTests.swift
@@ -826,7 +826,7 @@ extension PromiseTests {
   func testConcurrentDispatch1() {
     func next(_ idx: Int) -> Promise<()>? {
       guard idx < 10 else { return nil }
-      return async((), delay: .random(in: 0.01...0.5))
+      return async((), delay: .random(in: 0.01...0.05))
     }
     
     let ex = expectation(description: "")
@@ -838,7 +838,7 @@ extension PromiseTests {
   func testConcurrentDispatch2() {
     func next(_ idx: Int) -> Promise<()>? {
       guard idx < 10 else { return nil }
-      return async((), delay: .random(in: 0.01...0.5))
+      return async((), delay: .random(in: 0.01...0.05))
     }
     
     let ex = expectation(description: "")
@@ -850,7 +850,7 @@ extension PromiseTests {
   func testConcurrentDispatch3() {
     func next(_ idx: Int) -> Promise<()>? {
       guard idx < 10 else { return nil }
-      return async((), delay: .random(in: 0.01...0.5))
+      return async((), delay: .random(in: 0.01...0.05))
     }
     
     let ex = expectation(description: "")
@@ -862,7 +862,7 @@ extension PromiseTests {
   func testConcurrentDispatch4() {
     func next(_ idx: Int) -> Promise<()>? {
       guard idx < 10 else { return nil }
-      return async(NSError.err, Void.self, delay: .random(in: 0.01...0.5))
+      return async(NSError.err, Void.self, delay: .random(in: 0.01...0.05))
     }
     
     let ex = expectation(description: "")
@@ -877,7 +877,7 @@ extension PromiseTests {
       guard idx < 10 else { return nil }
       if !shouldFail.contains(idx) {
         shouldFail.insert(idx)
-        return async(NSError.err, Void.self, delay: .random(in: 0.01...0.5))
+        return async(NSError.err, Void.self, delay: .random(in: 0.01...0.05))
       }
       return async((), delay: .random(in: 0.01...1))
     }
@@ -1009,10 +1009,10 @@ extension PromiseTests {
 // MARK: - Sequence tests
 
 extension PromiseTests {
-  func testSequence1() {
+  func testSequenceSucceeds() {
     func next(_ idx: Int) -> Promise<Int>? {
       guard idx < 10 else { return nil }
-      return async(idx, delay: .random(in: 0.01...0.5))
+      return async(idx, delay: .random(in: 0.01...0.05))
     }
     
     let ex = expectation(description: "")
@@ -1021,15 +1021,15 @@ extension PromiseTests {
     waitForExpectations(timeout: 10)
   }
   
-  func testSequence2() {
+  func testSequenceSucceedsAfterRetrying() {
     var shouldFail = true
     func next(_ idx: Int) -> Promise<Int>? {
       guard idx < 1 else { return nil }
       if shouldFail {
         shouldFail = false
-        return async(NSError.err, Int.self, delay: .random(in: 0.01...0.5))
+        return async(NSError.err, Int.self, delay: .random(in: 0.01...0.05))
       }
-      return async(idx, delay: .random(in: 0.01...0.5))
+      return async(idx, delay: .random(in: 0.01...0.05))
     }
     
     let ex = expectation(description: "")
@@ -1038,9 +1038,9 @@ extension PromiseTests {
     waitForExpectations(timeout: 10)
   }
   
-  func testSequence3() {
+  func testSequenceFails() {
     func next(_ idx: Int) -> Promise<Int>? {
-      async(NSError.err, Int.self, delay: .random(in: 0.01...0.5))
+      async(NSError.err, Int.self, delay: .random(in: 0.01...0.05))
     }
     
     let ex = expectation(description: "")
@@ -1049,13 +1049,13 @@ extension PromiseTests {
     waitForExpectations(timeout: 10)
   }
   
-  func testSequence4() {
+  func testSequenceCollectionSucceeds() {
     let promises = [
-      { async(0, delay: .random(in: 0.01...0.5)) },
-      { async(1, delay: .random(in: 0.01...0.5)) },
-      { async(2, delay: .random(in: 0.01...0.5)) },
-      { async(3, delay: .random(in: 0.01...0.5)) },
-      { async(4, delay: .random(in: 0.01...0.5)) },
+      { async(0, delay: .random(in: 0.01...0.05)) },
+      { async(1, delay: .random(in: 0.01...0.05)) },
+      { async(2, delay: .random(in: 0.01...0.05)) },
+      { async(3, delay: .random(in: 0.01...0.05)) },
+      { async(4, delay: .random(in: 0.01...0.05)) },
     ]
     let ex = expectation(description: "")
     sequence(promises: promises)
@@ -1063,13 +1063,13 @@ extension PromiseTests {
     waitForExpectations(timeout: 10)
   }
   
-  func testSequence5() {
+  func testSequenceCollectionFails() {
     let promises = [
-      { async(0, delay: .random(in: 0.01...0.5)) },
-      { async(1, delay: .random(in: 0.01...0.5)) },
-      { async(2, delay: .random(in: 0.01...0.5)) },
-      { async(NSError.err, Int.self, delay: .random(in: 0.01...0.5)) },
-      { async(4, delay: .random(in: 0.01...0.5)) },
+      { async(0, delay: .random(in: 0.01...0.05)) },
+      { async(1, delay: .random(in: 0.01...0.05)) },
+      { async(2, delay: .random(in: 0.01...0.05)) },
+      { async(NSError.err, Int.self, delay: .random(in: 0.01...0.05)) },
+      { async(4, delay: .random(in: 0.01...0.05)) },
     ]
     let ex = expectation(description: "")
     sequence(promises: promises)


### PR DESCRIPTION
Implemented a `sequence` operator which executes tasks one by one. One could instead use `concurrentDispatch` with `concurrent` set to 1, but that involves unnecessary overhead of synchronization.

One example where this might be useful is, for instance, when you have to download several images and save them to Photos library, and the order is important.