### PR TITLE
Feature/XCTAssert+URLRequest

### DIFF
--- a/Sources/Core/Extensions/Other/XCTestCase+PovioKit.swift
+++ b/Sources/Core/Extensions/Other/XCTestCase+PovioKit.swift
@@ -10,11 +10,11 @@ import XCTest
 
 public extension XCTestCase {
   func XCTAssertEqualURLRequest(_ lhs: URLRequest?, _ rhs: URLRequest?, file: StaticString = #filePath, line: UInt = #line) {
-    XCTAssertEqual(lhs, rhs, file: file, line: line)
+    XCTAssertEqual(lhs, rhs, "Expected URLRequest to be equal", file: file, line: line)
     guard let lhs = lhs, let rhs = rhs else { return }
-    XCTAssertEqual(lhs.url, rhs.url, "url", file: file, line: line)
-    XCTAssertEqual(lhs.httpMethod, rhs.httpMethod, "httpMethod", file: file, line: line)
-    XCTAssertEqual(lhs.httpBody ?? Data(), rhs.httpBody ?? Data(), "httpBody", file: file, line: line)
-    XCTAssertEqual(lhs.allHTTPHeaderFields ?? [:], rhs.allHTTPHeaderFields ?? [:], "allHTTPHeaderFields", file: file, line: line)
+    XCTAssertEqual(lhs.url, rhs.url, "Expected url to be equal", file: file, line: line)
+    XCTAssertEqual(lhs.httpMethod, rhs.httpMethod, "Expected httpMethod to be equal", file: file, line: line)
+    XCTAssertEqual(lhs.httpBody ?? Data(), rhs.httpBody ?? Data(), "Expected httpBody to be equal", file: file, line: line)
+    XCTAssertEqual(lhs.allHTTPHeaderFields ?? [:], rhs.allHTTPHeaderFields ?? [:], "Expected HTTPHeaderFields to be equal", file: file, line: line)
   }
 }

--- a/Sources/Core/Extensions/Other/XCTestCase+PovioKit.swift
+++ b/Sources/Core/Extensions/Other/XCTestCase+PovioKit.swift
@@ -9,6 +9,16 @@
 import XCTest
 
 public extension XCTestCase {
+  /**
+   Use this method when you need to thoroughly assert URLRequest.
+   
+   Asserted properties:
+   - `Self`
+   - `url`
+   - `httpMethod`
+   - `httpBody`
+   - `allHTTPHeaderFields`
+   */
   func XCTAssertEqualURLRequest(_ lhs: URLRequest?, _ rhs: URLRequest?, file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertEqual(lhs, rhs, "Expected URLRequest to be equal", file: file, line: line)
     guard let lhs = lhs, let rhs = rhs else { return }
@@ -18,6 +28,16 @@ public extension XCTestCase {
     XCTAssertEqual(lhs.allHTTPHeaderFields ?? [:], rhs.allHTTPHeaderFields ?? [:], "Expected HTTPHeaderFields to be equal", file: file, line: line)
   }
   
+  /**
+   Use this method when you need to thoroughly assert URLRequest.
+   
+   Asserted properties:
+   - `Self`
+   - `url`
+   - `httpMethod`
+   - `httpBody`
+   - `allHTTPHeaderFields`
+   */
   func XCTAssertNotEqualURLRequest(_ lhs: URLRequest?, _ rhs: URLRequest?, file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertNotEqual(lhs, rhs, "Expected URLRequest not to be equal", file: file, line: line)
     guard let lhs = lhs, let rhs = rhs else { return }

--- a/Sources/Core/Extensions/Other/XCTestCase+PovioKit.swift
+++ b/Sources/Core/Extensions/Other/XCTestCase+PovioKit.swift
@@ -17,4 +17,13 @@ public extension XCTestCase {
     XCTAssertEqual(lhs.httpBody ?? Data(), rhs.httpBody ?? Data(), "Expected httpBody to be equal", file: file, line: line)
     XCTAssertEqual(lhs.allHTTPHeaderFields ?? [:], rhs.allHTTPHeaderFields ?? [:], "Expected HTTPHeaderFields to be equal", file: file, line: line)
   }
+  
+  func XCTAssertNotEqualURLRequest(_ lhs: URLRequest?, _ rhs: URLRequest?, file: StaticString = #filePath, line: UInt = #line) {
+    XCTAssertNotEqual(lhs, rhs, "Expected URLRequest not to be equal", file: file, line: line)
+    guard let lhs = lhs, let rhs = rhs else { return }
+    XCTAssertNotEqual(lhs.url, rhs.url, "Expected url not to be equal", file: file, line: line)
+    XCTAssertNotEqual(lhs.httpMethod, rhs.httpMethod, "Expected httpMethod not to be equal", file: file, line: line)
+    XCTAssertNotEqual(lhs.httpBody ?? Data(), rhs.httpBody ?? Data(), "Expected httpBody not to be equal", file: file, line: line)
+    XCTAssertNotEqual(lhs.allHTTPHeaderFields ?? [:], rhs.allHTTPHeaderFields ?? [:], "Expected HTTPHeaderFields not to be equal", file: file, line: line)
+  }
 }

--- a/Sources/Core/Extensions/Other/XCTestCase+PovioKit.swift
+++ b/Sources/Core/Extensions/Other/XCTestCase+PovioKit.swift
@@ -1,0 +1,20 @@
+//
+//  XCTestCase+PovioKit.swift
+//  PovioKit
+//
+//  Created by Gentian Barileva on 09/09/2022.
+//  Copyright © 2022 Povio Inc. All rights reserved.
+//
+
+import XCTest
+
+public extension XCTestCase {
+  func XCTAssertEqualURLRequest(_ lhs: URLRequest?, _ rhs: URLRequest?, file: StaticString = #filePath, line: UInt = #line) {
+    XCTAssertEqual(lhs, rhs, file: file, line: line)
+    guard let lhs = lhs, let rhs = rhs else { return }
+    XCTAssertEqual(lhs.url, rhs.url, "url", file: file, line: line)
+    XCTAssertEqual(lhs.httpMethod, rhs.httpMethod, "httpMethod", file: file, line: line)
+    XCTAssertEqual(lhs.httpBody ?? Data(), rhs.httpBody ?? Data(), "httpBody", file: file, line: line)
+    XCTAssertEqual(lhs.allHTTPHeaderFields ?? [:], rhs.allHTTPHeaderFields ?? [:], "allHTTPHeaderFields", file: file, line: line)
+  }
+}

--- a/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
+++ b/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
@@ -1,0 +1,11 @@
+//
+//  XCTestCaseTests.swift
+//  PovioKit_Tests
+//
+//  Created by Borut Tomazin on 15/09/2022.
+//  Copyright © 2022 Povio Inc. All rights reserved.
+//
+
+import XCTest
+
+final class XCTestCaseTests: XCTestCase { }

--- a/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
+++ b/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
@@ -60,6 +60,27 @@ final class XCTestCaseTests: XCTestCase {
     
     expectFailures(getRequest, postRequest, message: "Expected test to fail since httpHeaderField is different.")
   }
+  
+  func test_XCTAssertNotEqualURLRequest_passesOnDifferentURLRequest() {
+    let data1 = "TestData".data(using: .utf8)
+    let data2 = "Povio👨‍💻".data(using: .utf8)
+    
+    var firstUrlRequest = anyRequest()
+    firstUrlRequest.httpBody = data1
+    firstUrlRequest.httpMethod = "POST"
+    firstUrlRequest.setValue("", forHTTPHeaderField: "")
+    
+    var secondUrlRequest = anyRequest(urlString: "https://www.pov.io")
+    secondUrlRequest.httpBody = data2
+    firstUrlRequest.httpMethod = "PUT"
+    
+    XCTAssertNotEqualURLRequest(firstUrlRequest, secondUrlRequest)
+    XCTAssertNotEqual(firstUrlRequest, secondUrlRequest)
+    XCTAssertNotEqual(firstUrlRequest.url, secondUrlRequest.url)
+    XCTAssertNotEqual(firstUrlRequest.httpMethod, secondUrlRequest.httpMethod)
+    XCTAssertNotEqual(firstUrlRequest.httpBody ?? Data(), secondUrlRequest.httpBody ?? Data())
+    XCTAssertNotEqual(firstUrlRequest.allHTTPHeaderFields ?? [:], secondUrlRequest.allHTTPHeaderFields ?? [:])
+  }
 }
 
 // MARK: - Helpers

--- a/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
+++ b/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
@@ -10,14 +10,13 @@ import XCTest
 
 final class XCTestCaseTests: XCTestCase {
   func test_XCTAssertEqualURLRequest_httpBodyFailsOnDifferentDataSets() {
-    let url = URL(string: "https://www.povio.com")!
     let data1 = "TestData".data(using: .utf8)
     let data2 = "Povio🚀".data(using: .utf8)
     
-    var firstUrlRequest = URLRequest(url: url)
+    var firstUrlRequest = anyRequest()
     firstUrlRequest.httpBody = data1
     
-    var secondUrlRequest = URLRequest(url: url)
+    var secondUrlRequest = anyRequest()
     secondUrlRequest.httpBody = data2
     
     // Test passes even though httpBody is different.
@@ -30,14 +29,11 @@ final class XCTestCaseTests: XCTestCase {
   }
   
   func test_XCTAssertEqualURLRequest_hasExpectedFailures() {
-    let url1 = URL(string: "https://www.povio.com")!
-    let url2 = URL(string: "https://www.pov.io")!
-    
-    let firstUrlRequest = URLRequest(url: url1)
-    let secondUrlRequest = URLRequest(url: url2)
+    let firstUrlRequest = anyRequest()
+    let secondUrlRequest = anyRequest(urlString: "https://www.pov.io")
 
 
-    let possibleCombinations: [(URLRequest?, URLRequest?)] = [ (firstUrlRequest, nil),
+    let possibleCombinations: [(URLRequest?, URLRequest?)] = [(firstUrlRequest, nil),
                                                                (nil, secondUrlRequest),
                                                                (firstUrlRequest, secondUrlRequest)]
     
@@ -50,16 +46,23 @@ final class XCTestCaseTests: XCTestCase {
   }
   
   func test_XCTAssertEqualURLRequest_failsOnDifferentHttpMethods() {
-    let url = URL(string: "https://www.povio.com")!
-    var getRequest = URLRequest(url: url)
+    var getRequest = anyRequest()
     getRequest.httpMethod = "GET"
     
-    var postRequest = URLRequest(url: url)
+    var postRequest = anyRequest()
     postRequest.httpMethod = "POST"
     
     XCTExpectFailure("Expected test to fail since httpMethod is different.") {
       XCTAssertEqual(getRequest, postRequest)
       XCTAssertEqualURLRequest(getRequest, postRequest)
     }
+  }
+}
+
+// MARK: - Helpers
+private extension XCTestCaseTests {
+  func anyRequest(urlString: String = "https://www.povio.com") -> URLRequest {
+    let url = URL(string: urlString)!
+    return URLRequest(url: url)
   }
 }

--- a/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
+++ b/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
@@ -48,4 +48,18 @@ final class XCTestCaseTests: XCTestCase {
       }
     }
   }
+  
+  func test_XCTAssertEqualURLRequest_failsOnDifferentHttpMethods() {
+    let url = URL(string: "https://www.povio.com")!
+    var getRequest = URLRequest(url: url)
+    getRequest.httpMethod = "GET"
+    
+    var postRequest = URLRequest(url: url)
+    postRequest.httpMethod = "POST"
+    
+    XCTExpectFailure("Expected test to fail since httpMethod is different.") {
+      XCTAssertEqual(getRequest, postRequest)
+      XCTAssertEqualURLRequest(getRequest, postRequest)
+    }
+  }
 }

--- a/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
+++ b/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
@@ -28,4 +28,24 @@ final class XCTestCaseTests: XCTestCase {
       XCTAssertEqualURLRequest(firstUrlRequest, secondUrlRequest)
     }
   }
+  
+  func test_XCTAssertEqualURLRequest_hasExpectedFailures() {
+    let url1 = URL(string: "https://www.povio.com")!
+    let url2 = URL(string: "https://www.pov.io")!
+    
+    let firstUrlRequest = URLRequest(url: url1)
+    let secondUrlRequest = URLRequest(url: url2)
+
+
+    let possibleCombinations: [(URLRequest?, URLRequest?)] = [ (firstUrlRequest, nil),
+                                                               (nil, secondUrlRequest),
+                                                               (firstUrlRequest, secondUrlRequest)]
+    
+    possibleCombinations.forEach { combination in
+      XCTExpectFailure("Expected test to fail \(combination)") {
+        XCTAssertEqual(combination.0, combination.1)
+        XCTAssertEqualURLRequest(combination.0, combination.1)
+      }
+    }
+  }
 }

--- a/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
+++ b/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
@@ -57,6 +57,18 @@ final class XCTestCaseTests: XCTestCase {
       XCTAssertEqualURLRequest(getRequest, postRequest)
     }
   }
+  
+  func test_XCTAssertEqualURLRequest_failsOnDifferentHttpHeaderFields() {
+    var getRequest = anyRequest()
+    getRequest.setValue("", forHTTPHeaderField: "")
+    
+    let postRequest = anyRequest()
+    
+    XCTExpectFailure("Expected test to fail since httpHeaderField is different.") {
+      XCTAssertEqual(getRequest, postRequest)
+      XCTAssertEqualURLRequest(getRequest, postRequest)
+    }
+  }
 }
 
 // MARK: - Helpers

--- a/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
+++ b/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
@@ -8,4 +8,24 @@
 
 import XCTest
 
-final class XCTestCaseTests: XCTestCase { }
+final class XCTestCaseTests: XCTestCase {
+  func test_XCTAssertEqualURLRequest_httpBodyFailsOnDifferentDataSets() {
+    let url = URL(string: "https://www.povio.com")!
+    let data1 = "TestData".data(using: .utf8)
+    let data2 = "Povio🚀".data(using: .utf8)
+    
+    var firstUrlRequest = URLRequest(url: url)
+    firstUrlRequest.httpBody = data1
+    
+    var secondUrlRequest = URLRequest(url: url)
+    secondUrlRequest.httpBody = data2
+    
+    // Test passes even though httpBody is different.
+    XCTAssertEqual(firstUrlRequest, secondUrlRequest)
+    
+    XCTExpectFailure("Expected test to fail since httpBody is different.") {
+      XCTAssertEqual(firstUrlRequest.httpBody, secondUrlRequest.httpBody)
+      XCTAssertEqualURLRequest(firstUrlRequest, secondUrlRequest)
+    }
+  }
+}

--- a/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
+++ b/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
@@ -38,10 +38,7 @@ final class XCTestCaseTests: XCTestCase {
                                                                (firstUrlRequest, secondUrlRequest)]
     
     possibleCombinations.forEach { combination in
-      XCTExpectFailure("Expected test to fail \(combination)") {
-        XCTAssertEqual(combination.0, combination.1)
-        XCTAssertEqualURLRequest(combination.0, combination.1)
-      }
+      expectFailures(combination.0, combination.1, message: "Expected test to fail \(combination)")
     }
   }
   
@@ -52,10 +49,7 @@ final class XCTestCaseTests: XCTestCase {
     var postRequest = anyRequest()
     postRequest.httpMethod = "POST"
     
-    XCTExpectFailure("Expected test to fail since httpMethod is different.") {
-      XCTAssertEqual(getRequest, postRequest)
-      XCTAssertEqualURLRequest(getRequest, postRequest)
-    }
+    expectFailures(getRequest, postRequest, message: "Expected test to fail since httpMethod is different.")
   }
   
   func test_XCTAssertEqualURLRequest_failsOnDifferentHttpHeaderFields() {
@@ -64,10 +58,7 @@ final class XCTestCaseTests: XCTestCase {
     
     let postRequest = anyRequest()
     
-    XCTExpectFailure("Expected test to fail since httpHeaderField is different.") {
-      XCTAssertEqual(getRequest, postRequest)
-      XCTAssertEqualURLRequest(getRequest, postRequest)
-    }
+    expectFailures(getRequest, postRequest, message: "Expected test to fail since httpHeaderField is different.")
   }
 }
 
@@ -76,5 +67,12 @@ private extension XCTestCaseTests {
   func anyRequest(urlString: String = "https://www.povio.com") -> URLRequest {
     let url = URL(string: urlString)!
     return URLRequest(url: url)
+  }
+  
+  func expectFailures(_ lhs: URLRequest?, _ rhs: URLRequest?, message: String, file: StaticString = #filePath, line: UInt = #line) {
+    XCTExpectFailure(message) {
+      XCTAssertEqual(lhs, rhs, file: file, line: line)
+      XCTAssertEqualURLRequest(lhs, rhs, file: file, line: line)
+    }
   }
 }

--- a/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
+++ b/Tests/Tests/Core/Extensions/Other/XCTestCaseTests.swift
@@ -81,6 +81,26 @@ final class XCTestCaseTests: XCTestCase {
     XCTAssertNotEqual(firstUrlRequest.httpBody ?? Data(), secondUrlRequest.httpBody ?? Data())
     XCTAssertNotEqual(firstUrlRequest.allHTTPHeaderFields ?? [:], secondUrlRequest.allHTTPHeaderFields ?? [:])
   }
+  
+  func test_XCTAssertNotEqualURLRequest_passesOnDifferentURLRequestCombinations() {
+    let firstUrlRequest = anyRequest()
+    
+    var secondUrlRequest = anyRequest(urlString: "https://www.pov.io")
+    secondUrlRequest.httpBody = "Povio👨‍💻".data(using: .utf8)
+    secondUrlRequest.httpMethod = "PUT"
+    secondUrlRequest.setValue("", forHTTPHeaderField: "")
+
+    let possibleCombinations: [(URLRequest?, URLRequest?)] = [(firstUrlRequest, nil),
+                                                               (nil, secondUrlRequest),
+                                                               (firstUrlRequest, secondUrlRequest)]
+    
+    possibleCombinations.forEach { combination in
+      XCTAssertNotEqualURLRequest(combination.0, combination.1)
+    }
+    XCTExpectFailure("Expected nil URLRequest to not be equal") {
+      XCTAssertNotEqualURLRequest(nil, nil)
+    }
+  }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
Testing and asserting URLRequest-s isn't very reliable. Firstly there's no clear indicator as to why two URLRequests are different, it gives a generic message when it fails: 
<img width="505" alt="Screen Shot 2022-09-09 at 3 22 32 PM" src="https://user-images.githubusercontent.com/15278390/189359775-e02b227d-f57b-4148-8111-88b4266d0eaa.png">

--

The second one is that it does not compare the `httpBody` and therefore can give you a passing test when reality it isn't.
<img width="482" alt="Screen Shot 2022-09-09 at 3 13 41 PM" src="https://user-images.githubusercontent.com/15278390/189359154-3c088049-39c7-4d0f-9030-793f98f20c4b.png">

--

If we actually test for the `httpBody` we can see a failing test:
<img width="684" alt="Screen Shot 2022-09-09 at 3 14 21 PM" src="https://user-images.githubusercontent.com/15278390/189359249-9f8b7161-689e-494f-bb57-9125b4efbf1f.png">

--

With the help of this extension we can find out specifically what is failing and therefore fix it quickly.
<img width="798" alt="Screen Shot 2022-09-09 at 3 15 46 PM" src="https://user-images.githubusercontent.com/15278390/189359366-63a596e5-f009-41f2-8e53-a4fdc4b37ac8.png">
