### PR TITLE
Fix: Add PovioKitUI to Package testTarget

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,8 @@ let package = Package(
       dependencies: [
         "PovioKit",
         "PovioKitPromise",
-        "PovioKitNetworking"
+        "PovioKitNetworking",
+        "PovioKitUI"
       ]
     ),
   ],


### PR DESCRIPTION
Tests were failing to build, missing module PovioKitUI, Added PovioKitUI to Package testTarget