### PR TITLE
Chore/Auth updates

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,9 @@ let package = Package(
     ),
     .target(
       name: "PovioKitAuthCore",
-      dependencies: [],
+      dependencies: [
+        "PovioKitPromise"
+      ],
       path: "Sources/Auth/Core"
     ),
     .target(

--- a/Resources/Auth/Apple/README.md
+++ b/Resources/Auth/Apple/README.md
@@ -17,22 +17,29 @@ Please read [official documentation](https://developer.apple.com/sign-in-with-ap
 
 ```swift
 // initialization
-let provider = AppleAuthenticator() // conforms to `AppleAuthProvidable` protocol
+let authenticator = AppleAuthenticator() // conforms to `AppleAuthProvidable` protocol
 
 // signIn user
-provider
+authenticator
   .signIn(from: <view-controller-instance>)
+  .finally {
+    // handle result
+  }
+  
+// signIn user with nonce
+authenticator
+  .signIn(from: <view-controller-instance>, with: .random(length: 32))
   .finally {
     // handle result
   }
 
 // get auth status
-AppleAuthenticator
+authenticator
   .checkAuthState()
   .finally {
     // check result
   }
 
 // signOut user
-AppleAuthenticator.signOut() // all provider data regarding the use auth is cleared at this point
+authenticator.signOut() // all provider data regarding the use auth is cleared at this point
 ```

--- a/Resources/Auth/Facebook/README.md
+++ b/Resources/Auth/Facebook/README.md
@@ -9,19 +9,25 @@ Please read [official documentation](https://developers.facebook.com/docs/facebo
 
 ```swift
 // initialization
-let config = FacebookAuthenticator.Config()
-let provider = FacebookAuthenticator(with: config)
+let authenticator = FacebookAuthenticator()
 
-// signIn user
-provider
+// signIn user with default permissions
+authenticator
   .signIn(from: <view-controller-instance>)
   .finally {
     // handle result
   }
 
+// signIn user with custom permissions  
+authenticator
+  .signIn(from: <view-controller-instance>, with: [<array-of-custom-permissions>])
+  .finally {
+    // handle result
+  }
+
 // get auth status
-let state = FacebookAuthenticator.isAuthorized()
+let state = authenticator.isAuthenticated
 
 // signOut user
-FacebookAuthenticator.signOut() // all provider data regarding the use auth is cleared at this point
+authenticator.signOut() // all provider data regarding the use auth is cleared at this point
 ```

--- a/Resources/Auth/Google/README.md
+++ b/Resources/Auth/Google/README.md
@@ -10,7 +10,7 @@ Please read [official documentation](https://developers.google.com/identity/sign
 ```swift
 // initialization
 let config = GoogleAuthenticator.Config(clientId: "google-client-id")
-let provider = GoogleAuthenticator(with: config)
+let authenticator = GoogleAuthenticator(with: config)
 
 // signIn user
 provider
@@ -20,10 +20,10 @@ provider
   }
 
 // get auth status
-let state = GoogleAuthenticator.isAuthorized()
+let state = authenticator.isAuthenticated
 
 // signOut user
-GoogleAuthenticator.signOut() // all provider data regarding the use auth is cleared at this point
+authenticator.signOut() // all provider data regarding the use auth is cleared at this point
 
 // handle url
 GoogleAuthenticator.shouldHandleURL() // call this from `application:openURL:options:` in UIApplicationDelegate

--- a/Sources/Auth/Apple/AppleAuthenticator.swift
+++ b/Sources/Auth/Apple/AppleAuthenticator.swift
@@ -18,18 +18,18 @@ public protocol AppleAuthProvidable {
   func signIn(from presentingViewController: UIViewController) -> Promise<Response>
   func signIn(from presentingViewController: UIViewController,
               with nonce: AppleAuthenticator.Nonce) -> Promise<Response>
-  static func signOut()
-  static func checkAuthState() -> Promise<Authorized>
+  func signOut()
+  func checkAuthState() -> Promise<Authorized>
 }
 
 public final class AppleAuthenticator: NSObject {
-  private static let userIdStorageKey = "povioKit.appleSocialProvider.signIn.userId"
-  private static let storage: UserDefaults = .standard
-  private let authProvider: ASAuthorizationAppleIDProvider
+  private let userIdStorageKey = "povioKit.appleSocialProvider.signIn.userId"
+  private let storage: UserDefaults = .standard
+  private let provider: ASAuthorizationAppleIDProvider
   private var processingPromise: Promise<Response>?
   
   public override init() {
-    self.authProvider = .init()
+    self.provider = .init()
     super.init()
     setupCredentialsRevokeListener()
   }
@@ -63,13 +63,13 @@ extension AppleAuthenticator: AppleAuthProvidable {
   }
   
   /// Clears the signIn footprint and logs out the user immediatelly.
-  public static func signOut() {
+  public func signOut() {
     storage.removeObject(forKey: userIdStorageKey)
   }
   
   /// Checks the current auth state and returns the boolean value as promise.
-  public static func checkAuthState() -> PovioKitPromise.Promise<Authorized> {
-    guard let userId = Self.storage.string(forKey: Self.userIdStorageKey) else {
+  public func checkAuthState() -> Promise<Authorized> {
+    guard let userId = storage.string(forKey: userIdStorageKey) else {
       return .value(false)
     }
     
@@ -93,7 +93,7 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
       }
       
       // store userId for later
-      Self.storage.set(credential.user, forKey: Self.userIdStorageKey)
+      storage.set(credential.user, forKey: userIdStorageKey)
       
       // parse email and related metadata
       let email: AuthProvider.Response.Email? = credential.email.map {
@@ -125,7 +125,7 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
 // MARK: - Private Methods
 private extension AppleAuthenticator {
   func appleSignIn(on presentingViewController: UIViewController, with nonce: Nonce?) {
-    let request = authProvider.createRequest()
+    let request = provider.createRequest()
     request.requestedScopes = [.fullName, .email]
     
     switch nonce {

--- a/Sources/Auth/Apple/AppleAuthenticator.swift
+++ b/Sources/Auth/Apple/AppleAuthenticator.swift
@@ -59,6 +59,8 @@ extension AppleAuthenticator: AppleAuthProvidable {
   
   /// Clears the signIn footprint and logs out the user immediatelly.
   public func signOut() {
+    processingPromise?.reject(with: Authenticator.Error.cancelled)
+    processingPromise = nil
     storage.removeObject(forKey: userIdStorageKey)
   }
   

--- a/Sources/Auth/Core/AuthProvidable.swift
+++ b/Sources/Auth/Core/AuthProvidable.swift
@@ -1,0 +1,18 @@
+//
+//  AuthProvidable.swift
+//  PovioKit
+//
+//  Created by Borut Tomazin on 20/01/2023.
+//  Copyright © 2023 Povio Inc. All rights reserved.
+//
+
+import PovioKitPromise
+import UIKit
+
+public protocol AuthProvidable {
+  typealias Authenticated = Bool
+  typealias Response = Authenticator.Response
+  
+  func signIn(from presentingViewController: UIViewController) -> Promise<Response>
+  func signOut()
+}

--- a/Sources/Auth/Core/Authenticator.swift
+++ b/Sources/Auth/Core/Authenticator.swift
@@ -1,5 +1,5 @@
 //
-//  AuthProvider.swift
+//  Authenticator.swift
 //  PovioKit
 //
 //  Created by Borut Tomazin on 25/11/2022.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct AuthProvider {
+public struct Authenticator {
   public struct Response {
     public let token: String
     public let name: String?
@@ -32,7 +32,7 @@ public struct AuthProvider {
   }
 }
 
-public extension AuthProvider.Response {
+public extension Authenticator.Response {
   struct Email {
     public let address: String
     public let isPrivate: Bool?

--- a/Sources/Auth/Facebook/FacebookAuthenticator+Models.swift
+++ b/Sources/Auth/Facebook/FacebookAuthenticator+Models.swift
@@ -10,17 +10,6 @@ import Foundation
 import FacebookLogin
 
 public extension FacebookAuthenticator {
-  struct Config {
-    let permissions: [Permission] = [.email, .publicProfile]
-    /// By default, we request `email` and `publicProfile` permission.
-    /// If you want to request more permissions, define it here.
-    let extraPermissions: [Permission]
-    
-    public init(extraPermissions: [Permission] = []) {
-      self.extraPermissions = extraPermissions
-    }
-  }
-  
   struct GraphResponse: Decodable {
     let email: String?
     let firstName: String?

--- a/Sources/Auth/Facebook/FacebookAuthenticator.swift
+++ b/Sources/Auth/Facebook/FacebookAuthenticator.swift
@@ -32,6 +32,7 @@ public final class FacebookAuthenticator {
 extension FacebookAuthenticator: FacebookAuthProvidable {
   /// SignIn user.
   ///
+  /// The default permissions are used (e.g. `email` and `publicProfile`).
   /// Will return promise with the `Response` object on success or with `Error` on error.
   public func signIn(from presentingViewController: UIViewController) -> Promise<Response> {
     let permissions: [String] = defaultPermissions.map { $0.name }
@@ -41,8 +42,12 @@ extension FacebookAuthenticator: FacebookAuthProvidable {
       .flatMap(with: fetchUserDetails)
   }
   
-  public func signIn(from presentingViewController: UIViewController, with extraPermissions: [Permission]) -> Promise<Response> {
-    let permissions: [String] = (defaultPermissions + extraPermissions).map { $0.name }
+  /// SignIn user.
+  ///
+  /// The `permissions` to use when doing a sign in.
+  /// Will return promise with the `Response` object on success or with `Error` on error.
+  public func signIn(from presentingViewController: UIViewController, with permissions: [Permission]) -> Promise<Response> {
+    let permissions: [String] = permissions.map { $0.name }
     let configuration = LoginConfiguration(permissions: permissions, tracking: .limited)
     
     return signIn(with: configuration, on: presentingViewController)

--- a/Sources/Auth/Google/GoogleAuthenticator.swift
+++ b/Sources/Auth/Google/GoogleAuthenticator.swift
@@ -16,18 +16,18 @@ public protocol GoogleAuthProvidable {
   typealias Response = AuthProvider.Response
   
   func signIn(from presentingViewController: UIViewController) -> Promise<Response>
-  static func signOut()
-  static func isAuthorized() -> Authorized
+  func signOut()
+  func isAuthorized() -> Authorized
   static func shouldHandleURL(_ url: URL) -> Bool
 }
 
 public final class GoogleAuthenticator {
   private let config: Config
-  private let authProvider: GIDSignIn
+  private let provider: GIDSignIn
   
   public init(with config: Config) {
     self.config = config
-    self.authProvider = GIDSignIn.sharedInstance
+    self.provider = GIDSignIn.sharedInstance
   }
 }
 
@@ -37,13 +37,13 @@ extension GoogleAuthenticator: GoogleAuthProvidable {
   ///
   /// Will return promise with the `Response` object on success or with `Error` on error.
   public func signIn(from presentingViewController: UIViewController) -> Promise<Response> {
-    guard !authProvider.hasPreviousSignIn() else {
-      authProvider.restorePreviousSignIn()
+    guard !provider.hasPreviousSignIn() else {
+      provider.restorePreviousSignIn()
       return .error(AuthProvider.Error.alreadySignedIn)
     }
     
     return Promise { seal in
-      authProvider
+      provider
         .signIn(with: .init(clientID: config.clientId),
                 presenting: presentingViewController) { user, error in
           switch (user, error) {
@@ -78,13 +78,13 @@ extension GoogleAuthenticator: GoogleAuthProvidable {
   }
   
   /// Clears the signIn footprint and logs out the user immediatelly.
-  public static func signOut() {
-    GIDSignIn.sharedInstance.signOut()
+  public func signOut() {
+    provider.signOut()
   }
   
   /// Checks the current auth state and returns the boolean value.
-  public static func isAuthorized() -> Authorized {
-    GIDSignIn.sharedInstance.currentUser != nil
+  public func isAuthorized() -> Authorized {
+    provider.currentUser != nil
   }
   
   /// Boolean if given `url` should be handled.

--- a/Sources/Auth/Google/GoogleAuthenticator.swift
+++ b/Sources/Auth/Google/GoogleAuthenticator.swift
@@ -12,8 +12,6 @@ import PovioKitAuthCore
 import PovioKitPromise
 
 public protocol GoogleAuthProvidable: AuthProvidable {
-//  typealias Authenticated = Bool
-//  typealias Response = AuthProvider.Response
   var isAuthenticated: Authenticated { get }
   static func shouldHandleURL(_ url: URL) -> Bool
 }


### PR DESCRIPTION
I've made some improvements and changes based on the comments from the #229.

I've also re-introduced a protocol `AuthProvidable` to which all authenticators adhere. Why? Read further...

Imagine, you have some sort of a manager that handles auth. And you are covering e.g. "Apple" and "Google" auth. User signs in with Apple. When we need to perform some action, we just call `AuthProvidable` instance and call that method. We don't really care if authenticator is Apple or Google or anything else. If we went with the previous logic, we would first need to check which provider was selected, pick that one and call a method.

What do you think?