### PR TITLE
Chore/Rename main package to *Core

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/PovioKit-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/PovioKit-Package.xcscheme
@@ -98,6 +98,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "PovioKitAuthCore"
+               BuildableName = "PovioKitAuthCore"
+               BlueprintName = "PovioKitAuthCore"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "PovioKitAuthFacebook"
                BuildableName = "PovioKitAuthFacebook"
                BlueprintName = "PovioKitAuthFacebook"
@@ -126,9 +140,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "PovioKitAuthCore"
-               BuildableName = "PovioKitAuthCore"
-               BlueprintName = "PovioKitAuthCore"
+               BlueprintIdentifier = "PovioKitCore"
+               BuildableName = "PovioKitCore"
+               BlueprintName = "PovioKitCore"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,10 @@
 ## Migration Guides
 
+### Migration from versions < 3.0.0
+* [Core] The main package was renamed from `PovioKit` to `PovioKitCore`. You'll need to make a few changes in order to make this work:
+  * Remove library `PovioKit` under "Frameworks, Libraries, and Embedded Content" in Xcode and add a `PovioKitCore`.
+  * Replace all `import PovioKit` with `import PovioKitCore` in code.
+
 ### Migration from versions < 2.0.0
 * [Networking] File `OAuthRequestInterceptor` has been completely removed due to some critical issues. We encourage you to migrate to Alamofire's `Authenticator` protocol. Instructions can be found [here](Resources/Networking/AlamofireNetworkClient#oauth). Deprecated methods have also been removed.
 * [Package] The minimum supported version of iOS is 13. If you still support iOS 12, please evaluate this update.

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     .iOS(.v13)
   ],
   products: [
-    .library(name: "PovioKit", targets: ["PovioKit"]),
+    .library(name: "PovioKitCore", targets: ["PovioKitCore"]),
     .library(name: "PovioKitNetworking", targets: ["PovioKitNetworking"]),
     .library(name: "PovioKitPromise", targets: ["PovioKitPromise"]),
     .library(name: "PovioKitUI", targets: ["PovioKitUI"]),
@@ -23,13 +23,13 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "PovioKit",
+      name: "PovioKitCore",
       path: "Sources/Core"
     ),
     .target(
       name: "PovioKitNetworking",
       dependencies: [
-        "PovioKit",
+        "PovioKitCore",
         "Alamofire",
         "PovioKitPromise",
       ],
@@ -43,7 +43,7 @@ let package = Package(
     .target(
       name: "PovioKitUI",
       dependencies: [
-        "PovioKit"
+        "PovioKitCore"
       ],
       path: "Sources/UI"
     ),
@@ -80,7 +80,7 @@ let package = Package(
     .testTarget(
       name: "Tests",
       dependencies: [
-        "PovioKit",
+        "PovioKitCore",
         "PovioKitPromise",
         "PovioKitNetworking",
         "PovioKitUI",

--- a/Sources/Auth/Facebook/FacebookAuthenticator.swift
+++ b/Sources/Auth/Facebook/FacebookAuthenticator.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import FacebookLogin
-import PovioKit
+import PovioKitCore
 import PovioKitAuthCore
 import PovioKitPromise
 

--- a/Sources/Core/Extensions/UIKit/UIView+PovioKit.swift
+++ b/Sources/Core/Extensions/UIKit/UIView+PovioKit.swift
@@ -51,8 +51,8 @@ public extension UIView {
 // MARK: - Animations
 public extension UIView {
   struct AnimationKey {
-    static let rotation = "rotationAnimationKey"
-    static let shadowOpacity = "shadowOpacityKey"
+    public static let rotation = "rotationAnimationKey"
+    public static let shadowOpacity = "shadowOpacityKey"
   }
   
   func rotate(speed: CFTimeInterval = 1.25, clockwise: Bool = true) {

--- a/Sources/Networking/AlamofireNetworkClient/AlamofireConsoleLogger.swift
+++ b/Sources/Networking/AlamofireNetworkClient/AlamofireConsoleLogger.swift
@@ -8,7 +8,7 @@
 
 import Alamofire
 import Foundation
-import PovioKit
+import PovioKitCore
 
 public final class AlamofireConsoleLogger: EventMonitor {
   public let queue = DispatchQueue(label: "com.alamofire.console.networklogger")

--- a/Sources/Networking/AlamofireNetworkClient/AlamofireNetworkClient.swift
+++ b/Sources/Networking/AlamofireNetworkClient/AlamofireNetworkClient.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import Alamofire
-import PovioKit
+import PovioKitCore
 import PovioKitPromise
 
 public typealias URLEncoding = Alamofire.URLEncoding

--- a/Sources/Networking/AlamofireNetworkClient/Extensions/URLEncodedFormParameterEncoder+PovioKit.swift
+++ b/Sources/Networking/AlamofireNetworkClient/Extensions/URLEncodedFormParameterEncoder+PovioKit.swift
@@ -8,7 +8,7 @@
 
 import Alamofire
 import Foundation
-import PovioKit
+import PovioKitCore
 
 public extension URLEncodedFormParameterEncoder {
   convenience init(encoder: JSONEncoder,

--- a/Sources/UI/Camera/Camera.swift
+++ b/Sources/UI/Camera/Camera.swift
@@ -7,7 +7,7 @@
 //
 
 import AVFoundation
-import PovioKit
+import PovioKitCore
 
 public class Camera: NSObject {
   var device: AVCaptureDevice? {

--- a/Sources/UI/Camera/CameraService.swift
+++ b/Sources/UI/Camera/CameraService.swift
@@ -7,7 +7,7 @@
 //
 
 import AVFoundation.AVMediaFormat
-import PovioKit
+import PovioKitCore
 
 public struct CameraService {
   /* see extension bellow for implementation */

--- a/Sources/UI/TextField/TextField.swift
+++ b/Sources/UI/TextField/TextField.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import PovioKit
+import PovioKitCore
 
 public protocol RuleValidatable {
   var error: String { get }

--- a/Tests/Tests/Core/Extensions/Foundation/CollectionGroupedTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/CollectionGroupedTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 final class CollectionGroupedTests: XCTestCase {
   func test_grouped_returnsEmptyDictionaryOnEmptyArray() {

--- a/Tests/Tests/Core/Extensions/Foundation/CollectionTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/CollectionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 class CollectionTests: XCTestCase {
   func testSafeSubscript() {

--- a/Tests/Tests/Core/Extensions/Foundation/DecodableDictionaryTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/DecodableDictionaryTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 class DecodableDictionaryTests: XCTestCase {
   func testDecode() {

--- a/Tests/Tests/Core/Extensions/Foundation/DoubleTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/DoubleTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 class DoubleTests: XCTestCase {
   func test_convert_angles() {

--- a/Tests/Tests/Core/Extensions/Foundation/StringTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/StringTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 class StringTests: XCTestCase {
   func testLocalized() {

--- a/Tests/Tests/Core/Extensions/Foundation/URLTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/URLTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 class URLTests: XCTestCase {
   func testInitWithString() {

--- a/Tests/Tests/Core/Extensions/MapKit/MKAnnotationViewTests.swift
+++ b/Tests/Tests/Core/Extensions/MapKit/MKAnnotationViewTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 import MapKit.MKAnnotationView
 
 class MKAnnotationViewTests: XCTestCase {

--- a/Tests/Tests/Core/Extensions/UIKit/UICollectionReusableViewTests.swift
+++ b/Tests/Tests/Core/Extensions/UIKit/UICollectionReusableViewTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 class UICollectionReusableViewTests: XCTestCase {
   func test_identifier_returnsCorrectIdentifier() {

--- a/Tests/Tests/Core/Extensions/UIKit/UIColorTests.swift
+++ b/Tests/Tests/Core/Extensions/UIKit/UIColorTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import PovioKit
+import PovioKitCore
 
 class UIColorTests: XCTestCase {
   func testIfRed() {

--- a/Tests/Tests/Core/Extensions/UIKit/UIDeviceTests.swift
+++ b/Tests/Tests/Core/Extensions/UIKit/UIDeviceTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import PovioKit
+import PovioKitCore
 
 class UIDeviceTests: XCTestCase {
   func testAppVariablesNotEmpty() {

--- a/Tests/Tests/Core/Extensions/UIKit/UIEdgeInsetsTests.swift
+++ b/Tests/Tests/Core/Extensions/UIKit/UIEdgeInsetsTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 class UIEdgeInsetsTests: XCTestCase {
   func testAll() {

--- a/Tests/Tests/Core/Extensions/UIKit/UIResponderTests.swift
+++ b/Tests/Tests/Core/Extensions/UIKit/UIResponderTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 class UIResponderTests: XCTestCase {
   func test_firstResponder_returnsCorrectType() {

--- a/Tests/Tests/Core/Extensions/UIKit/UITableViewCellTests.swift
+++ b/Tests/Tests/Core/Extensions/UIKit/UITableViewCellTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 class TableViewCellIdentifierTests: XCTestCase {
   func test_identifier_returnsCorrectIdentifier() {    

--- a/Tests/Tests/Core/Extensions/UIKit/UITableViewHeaderFooterViewTests.swift
+++ b/Tests/Tests/Core/Extensions/UIKit/UITableViewHeaderFooterViewTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 class UITableViewHeaderFooterViewTests: XCTestCase {
   func test_identifier_returnsCorrectIdentifier() {

--- a/Tests/Tests/Core/Extensions/UIKit/UIViewControllerTests.swift
+++ b/Tests/Tests/Core/Extensions/UIKit/UIViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 import PovioKitUI
 
 class UIViewControllerTests: XCTestCase {  

--- a/Tests/Tests/Core/Extensions/UIKit/UIViewTests.swift
+++ b/Tests/Tests/Core/Extensions/UIKit/UIViewTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 import UIKit
-@testable import PovioKit
+import PovioKitCore
 
 class UIViewTests: XCTestCase {
   private let shadowPath: UIBezierPath = .init(rect: .init(x: 0, y: 0, width: 100, height: 100))

--- a/Tests/Tests/Core/Extensions/UIKit/UIWindowTests.swift
+++ b/Tests/Tests/Core/Extensions/UIKit/UIWindowTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 import UIKit
-@testable import PovioKit
+import PovioKitCore
 
 class UIWindowTests: XCTestCase {
   func test_safeAreaInsets() {

--- a/Tests/Tests/Core/Utilities/App Version Validator/AppVersionValidatorTests.swift
+++ b/Tests/Tests/Core/Utilities/App Version Validator/AppVersionValidatorTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import PovioKit
+import PovioKitCore
 
 class AppVersionValidatorTests: XCTestCase {
   func testValidator() {

--- a/Tests/Tests/Core/Utilities/AttributedStringBuilder/AttributedStringBuilderTests.swift
+++ b/Tests/Tests/Core/Utilities/AttributedStringBuilder/AttributedStringBuilderTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import PovioKit
+import PovioKitCore
 
 class AttributedStringBuilderTests: XCTestCase {
   func test_apply_addsAttributes() throws {

--- a/Tests/Tests/Core/Utilities/Broadcast/BroadcastTests.swift
+++ b/Tests/Tests/Core/Utilities/Broadcast/BroadcastTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import PovioKit
+import PovioKitCore
 
 class BroadcastTests: XCTestCase {
 

--- a/Tests/Tests/Core/Utilities/BundleReader/BundleReaderTests.swift
+++ b/Tests/Tests/Core/Utilities/BundleReader/BundleReaderTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 class BundleReaderTests: XCTestCase {
   func test_init_doesNotMessageTheReader() {

--- a/Tests/Tests/Core/Utilities/DispatchTimer/DispatchTimerTests.swift
+++ b/Tests/Tests/Core/Utilities/DispatchTimer/DispatchTimerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 final class DispatchTimerTests: XCTestCase {
   func test_dispatchTimer_instance_noRepeating() {

--- a/Tests/Tests/Core/Utilities/Money/MoneyTests.swift
+++ b/Tests/Tests/Core/Utilities/Money/MoneyTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import PovioKit
+import PovioKitCore
 
 class MoneyTests: XCTestCase {
   // MARK: - Testing Getters

--- a/Tests/Tests/Core/Utilities/StartupService/StartupProcessServiceTests.swift
+++ b/Tests/Tests/Core/Utilities/StartupService/StartupProcessServiceTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import PovioKit
+import PovioKitCore
 
 class StartupProcessServiceTests: XCTestCase {
   func testShouldCompleteProccesWhenCallExecution() {

--- a/Tests/Tests/Core/Utilities/Throttler/ThrottlerTests.swift
+++ b/Tests/Tests/Core/Utilities/Throttler/ThrottlerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import PovioKit
+@testable import PovioKitCore
 
 class ThrottlerTests: XCTestCase {
   func testShouldExecuteWhenDelayed() {

--- a/Tests/Tests/Core/Utilities/UserDefaults/UserDefaultTests.swift
+++ b/Tests/Tests/Core/Utilities/UserDefaults/UserDefaultTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import PovioKit
+import PovioKitCore
 
 class UserDefaultTests: XCTestCase {
   let userDefaults: UserDefaults = .standard

--- a/Tests/Tests/PromiseKit/EitherTests.swift
+++ b/Tests/Tests/PromiseKit/EitherTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import PovioKitPromise
+import PovioKitPromise
 
 class EitherTests: XCTestCase {
   func testIsLeftOrRight() {

--- a/Tests/Tests/PromiseKit/PromiseTests.swift
+++ b/Tests/Tests/PromiseKit/PromiseTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import PovioKitPromise
+import PovioKitPromise
 
 class PromiseTests: XCTestCase {
   // Covering some of the A+ spec (https://github.com/promises-aplus/promises-spec)

--- a/Tests/Tests/Utilities/XCConfigValue/MockBundleReader.swift
+++ b/Tests/Tests/Utilities/XCConfigValue/MockBundleReader.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-@testable import PovioKit
+import PovioKitCore
 
 class MockBundleReader: BundleReadable {
   private let dictionary: [String: Any]

--- a/Tests/Tests/Utilities/XCConfigValue/XCConfigValueTests.swift
+++ b/Tests/Tests/Utilities/XCConfigValue/XCConfigValueTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import PovioKit
+import PovioKitCore
 
 class XCConfigValueTests: XCTestCase {
   enum TestConfig {


### PR DESCRIPTION
Renamed `PovioKit` package to `PovioKitCore`.

Please note this is a major change and will need all clients to update the project and do the following:
1. Import new library `PovioKitCore` and remove redundant one `PovioKit`
2. Replace all `import PovioKit` with `import PovioKitCore`