### PR TITLE
Chore/SPM package update checker

### DIFF
--- a/.github/workflows/SPM.yml
+++ b/.github/workflows/SPM.yml
@@ -1,0 +1,13 @@
+name: SPM Outdated
+
+on: 
+  schedule:
+    - cron: '0 0 * * 7' # run every Sunday midnight
+
+jobs:
+  swiftpm:
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - uses: MeilCli/swiftpm-update-check-action@v3
+      id: outdated


### PR DESCRIPTION
Periodically check for outdated dependencies. Currently no action is taken, but we could send a slack message when outdated packages are found.