### PR TITLE
Chore/Auth improvements

### DIFF
--- a/Sources/Auth/Apple/AppleAuthenticator.swift
+++ b/Sources/Auth/Apple/AppleAuthenticator.swift
@@ -101,10 +101,10 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
       storage.setValue(true, forKey: storageAuthenticatedKey)
       
       // parse email and related metadata
-      let email: Response.Email? = credential.email.map {
-        let identity = try? JWTDecoder(token: identityTokenString)
-        let isEmailPrivate = identity?.bool(for: "is_private_email") ?? false
-        let isEmailVerified = identity?.bool(for: "email_verified") ?? false
+      let jwt = try? JWTDecoder(token: identityTokenString)
+      let email: Response.Email? = (credential.email ?? jwt?.string(for: "email")).map {
+        let isEmailPrivate = jwt?.bool(for: "is_private_email") ?? false
+        let isEmailVerified = jwt?.bool(for: "email_verified") ?? false
         return .init(address: $0, isPrivate: isEmailPrivate, isVerified: isEmailVerified)
       }
       

--- a/Sources/Auth/Core/SocialAuthenticationManager.swift
+++ b/Sources/Auth/Core/SocialAuthenticationManager.swift
@@ -10,7 +10,7 @@ import PovioKitPromise
 import Foundation
 import UIKit
 
-public class SocialAuthenticationManager {
+public final class SocialAuthenticationManager {
   private let authenticators: [Authenticator]
   
   public init(authenticators: [Authenticator]) {
@@ -36,6 +36,8 @@ extension SocialAuthenticationManager: Authenticator {
   }
   
   public func canOpenUrl(_ url: URL, application: UIApplication, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
-    currentAuthenticator?.canOpenUrl(url, application: application, options: options) ?? false
+    authenticators
+      .map { $0.canOpenUrl(url, application: application, options: options) }
+      .contains(true)
   }
 }

--- a/Sources/Auth/Core/SocialAuthenticationManager.swift
+++ b/Sources/Auth/Core/SocialAuthenticationManager.swift
@@ -36,8 +36,6 @@ extension SocialAuthenticationManager: Authenticator {
   }
   
   public func canOpenUrl(_ url: URL, application: UIApplication, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
-    authenticators
-      .map { $0.canOpenUrl(url, application: application, options: options) }
-      .contains(true)
+    authenticators.contains { $0.canOpenUrl(url, application: application, options: options) }
   }
 }


### PR DESCRIPTION
- email fallback for `AppleAuthenticator`
- simplified `canOpenUrl` on `SocialAuthenticationManager`