### PR TITLE
Hotfix/Handle Google Auth existing signin

### DIFF
--- a/Sources/Auth/Google/GoogleAuthenticator.swift
+++ b/Sources/Auth/Google/GoogleAuthenticator.swift
@@ -26,19 +26,33 @@ extension GoogleAuthenticator: Authenticator {
   /// Will return promise with the `Response` object on success or with `Error` on error.
   public func signIn(from presentingViewController: UIViewController) -> Promise<Response> {
     guard !provider.hasPreviousSignIn() else {
-      provider.restorePreviousSignIn()
-      return .error(Error.alreadySignedIn)
+      // restore user
+      return Promise { seal in
+        provider.restorePreviousSignIn { result, error in
+          switch (result, error) {
+          case (let user?, _):
+            let response = Response(token: user.accessToken.tokenString,
+                                    name: user.profile?.name,
+                                    email: user.profile?.email)
+            seal.resolve(with: response)
+          case (_, let actualError?):
+            seal.reject(with: Error.system(actualError))
+          case (.none, .none):
+            seal.reject(with: Error.unhandledAuthorization)
+          }
+        }
+      }
     }
     
+    // sign in
     return Promise { seal in
       provider
         .signIn(withPresenting: presentingViewController) { result, error in
           switch (result, error) {
           case (let signInResult?, _):
-            let userProfile = signInResult.user.profile
             let response = Response(token: signInResult.user.accessToken.tokenString,
-                                    name: userProfile?.name,
-                                    email: userProfile?.email)
+                                    name: signInResult.user.profile?.name,
+                                    email: signInResult.user.profile?.email)
             seal.resolve(with: response)
           case (_, let actualError?):
             let errorCode = (actualError as NSError).code

--- a/Sources/Auth/Google/GoogleAuthenticator.swift
+++ b/Sources/Auth/Google/GoogleAuthenticator.swift
@@ -31,10 +31,7 @@ extension GoogleAuthenticator: Authenticator {
         provider.restorePreviousSignIn { result, error in
           switch (result, error) {
           case (let user?, _):
-            let response = Response(token: user.accessToken.tokenString,
-                                    name: user.profile?.name,
-                                    email: user.profile?.email)
-            seal.resolve(with: response)
+            seal.resolve(with: user.authResponse)
           case (_, let actualError?):
             seal.reject(with: Error.system(actualError))
           case (.none, .none):
@@ -50,10 +47,7 @@ extension GoogleAuthenticator: Authenticator {
         .signIn(withPresenting: presentingViewController) { result, error in
           switch (result, error) {
           case (let signInResult?, _):
-            let response = Response(token: signInResult.user.accessToken.tokenString,
-                                    name: signInResult.user.profile?.name,
-                                    email: signInResult.user.profile?.email)
-            seal.resolve(with: response)
+            seal.resolve(with: signInResult.user.authResponse)
           case (_, let actualError?):
             let errorCode = (actualError as NSError).code
             if errorCode == GIDSignInError.Code.canceled.rawValue {
@@ -93,5 +87,14 @@ public extension GoogleAuthenticator {
     case cancelled
     case unhandledAuthorization
     case alreadySignedIn
+  }
+}
+
+// MARK: - Private Extension
+private extension GIDGoogleUser {
+  var authResponse: GoogleAuthenticator.Response {
+    .init(token: accessToken.tokenString,
+          name: profile?.name,
+          email: profile?.email)
   }
 }


### PR DESCRIPTION
When the user was already signed up with google, going through the signing flow would return `alreadySigned` error. We are now trying to return the same response as if he just signed in.