### PR TITLE
Fix/Make url optional for SwiftUI

### DIFF
--- a/Sources/UI/ProfileImageView/ProfileImageView.swift
+++ b/Sources/UI/ProfileImageView/ProfileImageView.swift
@@ -270,7 +270,7 @@ public extension ProfileImageView {
     return self
   }
   
-  func url(_ url: URL, placeholder: Image? = nil) -> Self {
+  func url(_ url: URL?, placeholder: Image? = nil) -> Self {
     properties.url = url
     properties.placeholder = placeholder
     return self


### PR DESCRIPTION
Make url optional for SwiftUI so we don't have to force unwrap URL initialization 