### PR TITLE
Make Alamofire URL Session public for easier customization

### DIFF
--- a/Sources/Networking/AlamofireNetworkClient/AlamofireNetworkClient.swift
+++ b/Sources/Networking/AlamofireNetworkClient/AlamofireNetworkClient.swift
@@ -22,7 +22,7 @@ public typealias ProgressHandler = Alamofire.Request.ProgressHandler
 public typealias ErrorHandler = (Swift.Error, Data) throws -> Swift.Error
 
 open class AlamofireNetworkClient {
-  private let session: Alamofire.Session
+  public let session: Alamofire.Session
   private let eventMonitors: [RequestMonitor]
   private let defaultErrorHandler: ErrorHandler?
   


### PR DESCRIPTION
With this, we enable runtime dynamic customization of the default Session, after creation which was currently not possible.