### PR TITLE
AsyncThrottleSequence/Bug fix

### DIFF
--- a/Sources/Async/AsyncThrottleSequence.swift
+++ b/Sources/Async/AsyncThrottleSequence.swift
@@ -130,7 +130,10 @@ extension AsyncThrottleSequence: AsyncSequence where C.Duration == Duration {
             try Task.checkCancellation()
             return result
           } catch {
-            return nil
+            if error is CancellationError {
+              return nil
+            }
+            throw error
           }
         }
         task = taskA


### PR DESCRIPTION
Return `nil` only if the thrown error is `CancellationError`, otherwise the error itself should be thrown.