### PR TITLE
Feature/Testing workflow improvements

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -22,8 +22,8 @@ jobs:
         xcode-version: latest-stable
 
     - name: Build project
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild build-for-testing -destination 'name=iPhone 14 Pro' -scheme 'PovioKit-Package' | xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild build-for-testing -destination 'name=iPhone 14 Pro' -scheme 'PovioKit-Package' | xcbeautify --renderer github-actions
 
     - name: Run tests
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -destination 'name=iPhone 14 Pro' -scheme 'PovioKit-Package' | xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -destination 'name=iPhone 14 Pro' -scheme 'PovioKit-Package' | xcbeautify --renderer github-actions
       

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -5,13 +5,14 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Tests:
     runs-on: macos-13
     steps:
-    - name: Cancel previous jobs
-      uses: styfle/cancel-workflow-action@0.11.0
-
     - name: Checkout Repository
       uses: actions/checkout@v3
 

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on: 
   push:
   pull_request:
-    types: [opened]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   Tests:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-13
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Load Latest Xcode
       uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
Hey-ya 👋,

Added some minor changes & improvements:

- Tests should run when a PR is opened, updated or reopened.
- Replaced `styfle/cancel-workflow-action` with `concurrency`, does same thing just more native.
- Updated `checkout` action to latest to alleviate warnings.
- Replaced `xcpretty` with `xcbeautify`, is up to 2x faster & has the option to show annotations(warnings, test results) directly on the summary.