### PR TITLE
AsyncThrottleSequence/Fixed error propagation

### DIFF
--- a/Sources/Async/AsyncThrottleSequence.swift
+++ b/Sources/Async/AsyncThrottleSequence.swift
@@ -116,35 +116,30 @@ extension AsyncThrottleSequence: AsyncSequence where C.Duration == Duration {
     /// - Throws: An error if the underlying `AsyncSequence` throws an error.
     /// - Returns: The next element in the sequence, or `nil` if there are no more elements.
     public func next() async throws -> Element? {
-      var task: Task<Element?, Error>?
-      
-      lock.withLock {
+      let task = lock.withLock {
         taskInExecution?.cancel()
         taskInExecution = nil
-        let taskA = Task {
-          try await Task.sleep(until: clock.now.advanced(by: delayBetweenTasks), clock: clock)
+        let task = Task {
+          try await Task.sleep(
+            until: clock.now.advanced(by: delayBetweenTasks),
+            clock: clock
+          )
           let result = try await baseIterator.next()
-          do {
-            // If task was cancelled while a request was being awaited,
-            // return `nil`!
-            try Task.checkCancellation()
-            return result
-          } catch {
-            if error is CancellationError {
-              return nil
-            }
-            throw error
-          }
+          try Task.checkCancellation()
+          return result
         }
-        task = taskA
-        taskInExecution = taskA
+        taskInExecution = task
+        return task
       }
       do {
-        return try await task?.value
+        return try await task.value
       } catch {
-        return nil
+        if error is CancellationError {
+          return nil
+        }
+        throw error
       }
-    }
+    } 
   }
   
   /// Creates a new iterator for the `AsyncThrottleSequence`.


### PR DESCRIPTION
Fixed the issue where error thrown by the throttled operation was not propagated to the caller.