### PR TITLE
`mutateEach(:)`

### DIFF
--- a/Sources/Core/Extensions/Foundation/Collection+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/Collection+PovioKit.swift
@@ -48,11 +48,11 @@ public extension Collection {
 }
 
 public extension MutableCollection {
-  mutating func mutateEach(_ f: (inout Element) throws -> Void) rethrows {
-    var i = startIndex
-    while i != endIndex {
-      try f(&self[i])
-      formIndex(after: &i)
+  mutating func mutateEach(_ mutator: (inout Element) throws -> Void) rethrows {
+    var idx = startIndex
+    while idx != endIndex {
+      try mutator(&self[idx])
+      formIndex(after: &idx)
     }
   }
 }

--- a/Sources/Core/Extensions/Foundation/Collection+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/Collection+PovioKit.swift
@@ -29,9 +29,7 @@ public extension Collection {
       }
     }
   }
-}
-
-public extension Collection {
+  
   /// Groups collection elements based on dateComponents returning a dictionary
   func grouped(
     extractDate: (Element) -> Date,
@@ -46,5 +44,15 @@ public extension Collection {
         return date
       }
     )
+  }
+}
+
+public extension MutableCollection {
+  mutating func mutateEach(_ f: (inout Element) throws -> Void) rethrows {
+    var i = startIndex
+    while i != endIndex {
+      try f(&self[i])
+      formIndex(after: &i)
+    }
   }
 }

--- a/Tests/Tests/Core/Extensions/Foundation/CollectionTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/CollectionTests.swift
@@ -22,4 +22,23 @@ class CollectionTests: XCTestCase {
     XCTAssertEqual(array.count(where: { $0 is String}), 2)
     XCTAssertEqual(array.count(where: { $0 is Int}), 2)
   }
+  
+  func testMutateEach1() {
+    var array = [1, 2, 3, 4, 5]
+    array.mutateEach { $0 *= 2 }
+    XCTAssertEqual(array, [2, 4, 6, 8, 10])
+  }
+  
+  func testMutateEach2() {
+    struct A: Equatable {
+      var x = true
+      
+      mutating func mutate() {
+        x.toggle()
+      }
+    }
+    var array = [A](repeating: .init(), count: 5)
+    array.mutateEach { $0.mutate() }
+    XCTAssertEqual(array, .init(repeating: .init(x: false), count: 5))
+  }
 }


### PR DESCRIPTION
Implemented a mutable version of `forEach`.

Instead of writing smth like

```swift
for idx in 0..<c.count {
  c[idx].mutate()
}
```
, you can use `mutateEach`:

```swift
c.mutateEach { $0.mutate() }
```