### PR TITLE
[Fix] Camera crash on deallocation

### DIFF
--- a/Sources/Utilities/Camera/Camera.swift
+++ b/Sources/Utilities/Camera/Camera.swift
@@ -70,7 +70,7 @@ public extension Camera {
   }
   
   func stopSession() {
-    sessionQueue.async {
+    sessionQueue.sync {
       guard self.session.isRunning else { return }
       self.session.stopRunning()
     }


### PR DESCRIPTION
Deallocating the camera object after calling `stopSession` can sometimes produce a crash; using `sync` instead of `async` on the queue prevents this as the object is kept around until the session actually stops :)

Repro is quite simple - create a view of some kind that holds an optional reference to the camera (qrscanner in my case), calls `stopCamera()` and also nils the reference at the same time. This crashes the app with `EXC_BAD_ACCESS` on `guard self.session.isRunning` in `Camera.swift`

Applying this patch fixes the issue :)