### PR TITLE
Feature/Add Continuous Autofocus in QRCodeScanner

### DIFF
--- a/Sources/Utilities/Camera/QRCodeScanner.swift
+++ b/Sources/Utilities/Camera/QRCodeScanner.swift
@@ -55,13 +55,11 @@ private extension QRCodeScanner {
     guard let device = device else { throw Camera.Error.unavailable }
 
     if device.isFocusModeSupported(.continuousAutoFocus) {
-      do {
-        try device.lockForConfiguration()
-        device.focusMode = .continuousAutoFocus
-        device.unlockForConfiguration()
-      }
+      try device.lockForConfiguration()
+      device.focusMode = .continuousAutoFocus
+      device.unlockForConfiguration()
     }
-    
+
     session.beginConfiguration()
     
     // add input

--- a/Sources/Utilities/Camera/QRCodeScanner.swift
+++ b/Sources/Utilities/Camera/QRCodeScanner.swift
@@ -53,6 +53,14 @@ extension QRCodeScanner: AVCaptureMetadataOutputObjectsDelegate {
 private extension QRCodeScanner {
   func configure() throws {
     guard let device = device else { throw Camera.Error.unavailable }
+
+    if device.isFocusModeSupported(.continuousAutoFocus) {
+      do {
+        try device.lockForConfiguration()
+        device.focusMode = .continuousAutoFocus
+        device.unlockForConfiguration()
+      }
+    }
     
     session.beginConfiguration()
     


### PR DESCRIPTION
While scanning the QR code, the camera loses focus and is unable to scan it.

This PR adds the autofocus feature specifically for QRCodeScanner, which always requires it to be enabled.