### PR TITLE
Fix/Markdown

### DIFF
--- a/Sources/Core/Extensions/Foundation/String+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/String+PovioKit.swift
@@ -83,7 +83,8 @@ public extension String {
   @available(iOS 15, *)
   func toMarkdown() -> AttributedString {
     do {
-      return try AttributedString(markdown: self)
+      let options = AttributedString.MarkdownParsingOptions(interpretedSyntax: .full)
+      return try AttributedString(markdown: self, options: options)
     } catch {
       return AttributedString(self)
     }

--- a/Sources/Core/Extensions/Foundation/String+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/String+PovioKit.swift
@@ -79,11 +79,16 @@ public extension String {
   /// Converts the string into a markdown formatted AttributedString.
   ///
   /// If the conversion fails (e.g., due to invalid markdown syntax), it returns the original string as an AttributedString.
+  /// - Parameter options: Configures the markdown parsing behavior. Some developers have reported that the full parsing is too strict and sometimes
+  /// doesn't render new lines. Use `.inlineOnlyPreservingWhitespace` for a more lenient parsing.
   /// - Precondition: Requires iOS 15 and above.
   @available(iOS 15, *)
-  func toMarkdown() -> AttributedString {
+  func toMarkdown(
+    options: AttributedString.MarkdownParsingOptions = AttributedString.MarkdownParsingOptions(
+      interpretedSyntax: .full
+    )
+  ) -> AttributedString {
     do {
-      let options = AttributedString.MarkdownParsingOptions(interpretedSyntax: .full)
       return try AttributedString(markdown: self, options: options)
     } catch {
       return AttributedString(self)


### PR DESCRIPTION
This PR fixes markdown interpretation to include elements that were not displayed correctly previously:
- headers
- lists
- code blocks
- blockquotes
- tables