### PR TITLE
Fix/Changing the safari schema to > ios 17.5 for openUrl

### DIFF
--- a/Sources/Core/AppInfo.swift
+++ b/Sources/Core/AppInfo.swift
@@ -43,7 +43,7 @@ public enum AppInfo {
   public static func openUrl(_ url: URL, inSafari: Bool = false) {
     var targetUrl = url
 #if os(iOS)
-    if inSafari, #available(iOS 17.0, *) {
+    if inSafari, #available(iOS 17.5, *) {
       targetUrl = URL(string: "x-safari-\(url.absoluteString)")!
     }
     guard UIApplication.shared.canOpenURL(targetUrl) else { return }


### PR DESCRIPTION
I noticed an issue on IOS 17.0 where the `openUrl` function when `inSafari=true` wouldn't open the URL due to the safari schema not working on that version. It turns out it only is supported on ios 17.5 and above.

Updated the util function to have the correct versioning logic in place