### PR TITLE
Swiftui/RemoteImage processors

### DIFF
--- a/Sources/UI/SwiftUI/Views/RemoteImage/HEICImageProcessor.swift
+++ b/Sources/UI/SwiftUI/Views/RemoteImage/HEICImageProcessor.swift
@@ -1,0 +1,145 @@
+//
+//  HEICImageProcessor.swift
+//  PovioKit
+//
+//  Created by Borut Tomazin on 25/02/2025.
+//  Copyright © 2025 Povio Inc. All rights reserved.
+//
+
+import Kingfisher
+#if canImport(UIKit)
+import UIKit
+import ImageIO
+import CoreServices
+#elseif canImport(AppKit)
+import AppKit
+import ImageIO
+import CoreServices
+#endif
+
+/// An image processor that compresses images to HEIC format to reduce memory footprint.
+///
+/// HEIC (High Efficiency Image Container) provides superior compression compared to JPEG,
+/// typically achieving 50% smaller file sizes at similar quality levels. This processor
+/// is ideal for iOS and macOS applications where maximum compression efficiency is desired.
+///
+/// **Note:** HEIC format is supported on iOS 11+ and macOS 10.13+. On older systems,
+/// the processor will fall back to returning the original image.
+///
+/// ## Example
+/// ```swift
+/// let processor = DownsamplingImageProcessor(size: CGSize(width: 1200, height: 600))
+///     |> HEICImageProcessor(compressionQuality: 0.8)
+/// RemoteImage(url: imageURL)
+///     .processor(processor)
+/// ```
+public struct HEICImageProcessor: ImageProcessor {
+  /// The compression quality, ranging from 0.0 (maximum compression, lowest quality)
+  /// to 1.0 (no compression, highest quality).
+  public let compressionQuality: CGFloat
+  
+  /// A unique identifier for this processor.
+  public let identifier: String
+  
+  /// Creates a HEIC image processor with the specified compression quality.
+  ///
+  /// - Parameter compressionQuality: The compression quality (0.0 to 1.0).
+  ///   Default is 0.8, which provides a good balance between file size and quality.
+  ///   - 0.9-1.0: High quality, larger file size
+  ///   - 0.7-0.8: Balanced (recommended)
+  ///   - 0.5-0.6: High compression, smaller file size
+  public init(compressionQuality: CGFloat = 0.8) {
+    self.compressionQuality = max(0.0, min(1.0, compressionQuality))
+    self.identifier = "com.povio.HEICImageProcessor(\(compressionQuality))"
+  }
+  
+  public func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
+    switch item {
+    case .image(let image):
+      #if canImport(UIKit)
+      return convertToHEIC(image: image, quality: compressionQuality) ?? image
+      #elseif canImport(AppKit)
+      return convertToHEIC(image: image, quality: compressionQuality) ?? image
+      #else
+      return image
+      #endif
+      
+    case .data(let data):
+      #if canImport(UIKit)
+      return UIImage(data: data)
+      #elseif canImport(AppKit)
+      return NSImage(data: data)
+      #else
+      return nil
+      #endif
+    }
+  }
+  
+  #if canImport(UIKit)
+  private func convertToHEIC(image: UIImage, quality: CGFloat) -> UIImage? {
+    guard let imageData = image.heicData(compressionQuality: quality),
+          let heicImage = UIImage(data: imageData) else {
+      return nil
+    }
+    return heicImage
+  }
+  #elseif canImport(AppKit)
+  private func convertToHEIC(image: NSImage, quality: CGFloat) -> NSImage? {
+    guard let imageData = image.heicData(compressionQuality: quality),
+          let heicImage = NSImage(data: imageData) else {
+      return nil
+    }
+    return heicImage
+  }
+  #endif
+}
+
+#if canImport(UIKit)
+private extension UIImage {
+  func heicData(compressionQuality: CGFloat) -> Data? {
+    guard let mutableData = CFDataCreateMutable(nil, 0),
+          let destination = CGImageDestinationCreateWithData(mutableData, "public.heic" as CFString, 1, nil),
+          let cgImage = self.cgImage else {
+      return nil
+    }
+    
+    let options: [CFString: Any] = [
+      kCGImageDestinationLossyCompressionQuality: compressionQuality
+    ]
+    
+    CGImageDestinationAddImage(destination, cgImage, options as CFDictionary)
+    guard CGImageDestinationFinalize(destination) else {
+      return nil
+    }
+    
+    return mutableData as Data
+  }
+}
+#elseif canImport(AppKit)
+private extension NSImage {
+  func heicData(compressionQuality: CGFloat) -> Data? {
+    guard let tiffData = self.tiffRepresentation,
+          let bitmapImage = NSBitmapImageRep(data: tiffData),
+          let cgImage = bitmapImage.cgImage else {
+      return nil
+    }
+    
+    guard let mutableData = CFDataCreateMutable(nil, 0),
+          let destination = CGImageDestinationCreateWithData(mutableData, "public.heic" as CFString, 1, nil) else {
+      return nil
+    }
+    
+    let options: [CFString: Any] = [
+      kCGImageDestinationLossyCompressionQuality: compressionQuality
+    ]
+    
+    CGImageDestinationAddImage(destination, cgImage, options as CFDictionary)
+    guard CGImageDestinationFinalize(destination) else {
+      return nil
+    }
+    
+    return mutableData as Data
+  }
+}
+#endif
+

--- a/Sources/UI/SwiftUI/Views/RemoteImage/JPEGImageProcessor.swift
+++ b/Sources/UI/SwiftUI/Views/RemoteImage/JPEGImageProcessor.swift
@@ -1,0 +1,80 @@
+//
+//  JPEGImageProcessor.swift
+//  PovioKit
+//
+//  Created by Borut Tomazin on 25/02/2025.
+//  Copyright © 2025 Povio Inc. All rights reserved.
+//
+
+import Kingfisher
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+/// An image processor that compresses images to JPEG format to reduce memory footprint.
+///
+/// This processor converts images to JPEG format with a specified compression quality.
+/// It's useful for reducing memory usage, especially when combined with downsampling.
+///
+/// ## Example
+/// ```swift
+/// let processor = DownsamplingImageProcessor(size: CGSize(width: 1200, height: 600))
+///     |> JPEGImageProcessor(compressionQuality: 0.8)
+/// RemoteImage(url: imageURL)
+///     .processor(processor)
+/// ```
+public struct JPEGImageProcessor: ImageProcessor {
+  /// The compression quality, ranging from 0.0 (maximum compression, lowest quality)
+  /// to 1.0 (no compression, highest quality).
+  public let compressionQuality: CGFloat
+  
+  /// A unique identifier for this processor.
+  public let identifier: String
+  
+  /// Creates a JPEG image processor with the specified compression quality.
+  ///
+  /// - Parameter compressionQuality: The compression quality (0.0 to 1.0).
+  ///   Default is 0.8, which provides a good balance between file size and quality.
+  ///   - 0.9-1.0: High quality, larger file size
+  ///   - 0.7-0.8: Balanced (recommended)
+  ///   - 0.5-0.6: High compression, smaller file size
+  public init(compressionQuality: CGFloat = 0.8) {
+    self.compressionQuality = max(0.0, min(1.0, compressionQuality))
+    self.identifier = "com.povio.JPEGImageProcessor(\(compressionQuality))"
+  }
+  
+  public func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
+    switch item {
+    case .image(let image):
+      #if canImport(UIKit)
+      guard let jpegData = image.jpegData(compressionQuality: compressionQuality),
+            let compressedImage = UIImage(data: jpegData) else {
+        return image
+      }
+      return compressedImage
+      #elseif canImport(AppKit)
+      guard let tiffData = image.tiffRepresentation,
+            let bitmapImage = NSBitmapImageRep(data: tiffData),
+            let jpegData = bitmapImage.representation(using: .jpeg, properties: [.compressionFactor: compressionQuality]),
+            let compressedImage = NSImage(data: jpegData) else {
+        return image
+      }
+      return compressedImage
+      #else
+      return image
+      #endif
+      
+    case .data(let data):
+      #if canImport(UIKit)
+      return UIImage(data: data)
+      #elseif canImport(AppKit)
+      return NSImage(data: data)
+      #else
+      return nil
+      #endif
+    }
+  }
+}
+

--- a/Sources/UI/SwiftUI/Views/RemoteImage/RemoteImage.swift
+++ b/Sources/UI/SwiftUI/Views/RemoteImage/RemoteImage.swift
@@ -14,8 +14,8 @@ import SwiftUI
 /// If Kingfisher is available, it uses `KFImage` for image loading to support caching,
 /// otherwise it falls back to SwiftUI's `AsyncImage`.
 ///
-/// The `RemoteImage` can be parameterized with a custom placeholder view and an
-/// option for fade animation.
+/// The `RemoteImage` can be parameterized with a custom placeholder view, an
+/// option for fade animation, and a Kingfisher image processor.
 ///
 /// ## Example with placeholder
 /// ```swift
@@ -31,10 +31,18 @@ import SwiftUI
 ///     print("Failed to load image: \(error)")
 ///   }
 /// ```
+///
+/// ## Example with image processor
+/// ```swift
+/// let processor = DownsamplingImageProcessor(size: CGSize(width: 200, height: 200))
+/// RemoteImage(url: URL(string: "https://example.com/image.jpg"))
+///   .processor(processor)
+/// ```
 public struct RemoteImage<Placeholder: View>: View {
   private let url: URL?
   private let animated: Bool
   private var placeholder: Placeholder?
+  private var processor: ImageProcessor?
   private var onSuccess: ((RetrieveImageResult) -> Void)?
   private var onFailure: ((KingfisherError) -> Void)?
   
@@ -45,6 +53,7 @@ public struct RemoteImage<Placeholder: View>: View {
     self.url = url
     self.animated = animated
     self.placeholder = EmptyView()
+    self.processor = nil
     self.onSuccess = nil
     self.onFailure = nil
   }
@@ -53,25 +62,39 @@ public struct RemoteImage<Placeholder: View>: View {
     url: URL?,
     animated: Bool = false,
     placeholder: Placeholder?,
+    processor: ImageProcessor? = nil,
     onSuccess: ((RetrieveImageResult) -> Void)? = nil,
     onFailure: ((KingfisherError) -> Void)? = nil
   ) {
     self.url = url
     self.animated = animated
     self.placeholder = placeholder
+    self.processor = processor
     self.onSuccess = onSuccess
     self.onFailure = onFailure
   }
   
   public var body: some View {
     if let url {
-      KFImage(url)
-        .onSuccess(onSuccess)
-        .onFailure(onFailure)
-        .placeholder { placeholder }
-        .fade(duration: animated ? 0.25 : 0)
-        .resizable()
-        .scaledToFill()
+      let baseImage = KFImage(url)
+      if let processor {
+        baseImage
+          .setProcessor(processor)
+          .onSuccess(onSuccess)
+          .onFailure(onFailure)
+          .placeholder { placeholder }
+          .fade(duration: animated ? 0.25 : 0)
+          .resizable()
+          .scaledToFill()
+      } else {
+        baseImage
+          .onSuccess(onSuccess)
+          .onFailure(onFailure)
+          .placeholder { placeholder }
+          .fade(duration: animated ? 0.25 : 0)
+          .resizable()
+          .scaledToFill()
+      }
     } else {
       placeholder
     }
@@ -91,6 +114,23 @@ public extension RemoteImage {
       url: url,
       animated: animated,
       placeholder: placeholder(),
+      processor: processor,
+      onSuccess: onSuccess,
+      onFailure: onFailure
+    )
+  }
+  
+  /// Sets a Kingfisher image processor for the `RemoteImage`.
+  ///
+  /// - Parameter processor: An `ImageProcessor` instance to process the image before display.
+  ///   Common processors include `DownsamplingImageProcessor`, `RoundCornerImageProcessor`, etc.
+  /// - Returns: A new `RemoteImage` instance with the specified processor.
+  func processor(_ processor: ImageProcessor?) -> RemoteImage {
+    RemoteImage(
+      url: url,
+      animated: animated,
+      placeholder: placeholder,
+      processor: processor,
       onSuccess: onSuccess,
       onFailure: onFailure
     )
@@ -105,6 +145,7 @@ public extension RemoteImage {
       url: url,
       animated: animated,
       placeholder: placeholder,
+      processor: processor,
       onSuccess: callback,
       onFailure: onFailure
     )
@@ -119,6 +160,7 @@ public extension RemoteImage {
       url: url,
       animated: animated,
       placeholder: placeholder,
+      processor: processor,
       onSuccess: onSuccess,
       onFailure: callback
     )

--- a/Sources/UI/SwiftUI/Views/RemoteImage/RemoteImage.swift
+++ b/Sources/UI/SwiftUI/Views/RemoteImage/RemoteImage.swift
@@ -38,6 +38,22 @@ import SwiftUI
 /// RemoteImage(url: URL(string: "https://example.com/image.jpg"))
 ///   .processor(processor)
 /// ```
+///
+/// ## Example with downsampling and JPEG compression
+/// ```swift
+/// let processor = DownsamplingImageProcessor(size: CGSize(width: 1200, height: 600))
+///     |> JPEGImageProcessor(compressionQuality: 0.8)
+/// RemoteImage(url: URL(string: "https://example.com/image.jpg"))
+///   .processor(processor)
+/// ```
+///
+/// ## Example with downsampling and HEIC compression (best compression)
+/// ```swift
+/// let processor = DownsamplingImageProcessor(size: CGSize(width: 1200, height: 600))
+///     |> HEICImageProcessor(compressionQuality: 0.8)
+/// RemoteImage(url: URL(string: "https://example.com/image.jpg"))
+///   .processor(processor)
+/// ```
 public struct RemoteImage<Placeholder: View>: View {
   private let url: URL?
   private let animated: Bool
@@ -123,7 +139,8 @@ public extension RemoteImage {
   /// Sets a Kingfisher image processor for the `RemoteImage`.
   ///
   /// - Parameter processor: An `ImageProcessor` instance to process the image before display.
-  ///   Common processors include `DownsamplingImageProcessor`, `RoundCornerImageProcessor`, etc.
+  ///   Common processors include `DownsamplingImageProcessor`, `RoundCornerImageProcessor`,
+  ///   `JPEGImageProcessor`, `HEICImageProcessor`, etc. Processors can be chained using the `|>` operator.
   /// - Returns: A new `RemoteImage` instance with the specified processor.
   func processor(_ processor: ImageProcessor?) -> RemoteImage {
     RemoteImage(


### PR DESCRIPTION
Added JPEG and HEIC image custom processors. You can always use stock ones as well, e.g. `DownsamplingImageProcessor`.