### PR TITLE
Swiftui/View modifiers

### DIFF
--- a/Resources/Core/Extensions/NotificationCenter+PovioKit.md
+++ b/Resources/Core/Extensions/NotificationCenter+PovioKit.md
@@ -1,0 +1,73 @@
+# NotificationCenter+PovioKit
+
+`PovioKitCore` includes generic `NotificationCenter` helpers in
+`NotificationCenter+PovioKit.swift`.
+
+For common UIKit events, `PovioKitCore` also provides:
+
+- `AppNotification.onAppResume`
+- `AppNotification.onAppPause`
+- `AppNotification.onScreenshot`
+- `AppNotification.keyboardWillShow`
+- `AppNotification.keyboardWillHide`
+- `AppNotification.deviceDidShake`
+
+`AppNotification.deviceDidShake` is intentionally app-emitted. PovioKit observes it,
+but your app is responsible for posting it when shake is detected.
+
+## 1) Create notifications
+
+Use `AppNotification` as a single entrypoint for both built-in and custom names.
+
+```swift
+import Foundation
+import UIKit
+import PovioKitCore
+
+let signInComplete = AppNotification.named("com.myapp.notification.signInComplete")
+let deeplink = AppNotification.named("com.myapp.notification.openDeepLink")
+```
+
+## 2) Publish and observe
+
+Use typed helpers for posting, observing, and Combine publishers.
+
+```swift
+import Combine
+
+final class SessionObserver {
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        NotificationCenter
+            .publisher(for: AppNotification.onAppResume)
+            .sink { notification in
+                print("App resumed: \(notification)")
+            }
+            .store(in: &cancellables)
+
+        let customNotification = AppNotification.named("com.myapp.notification.signInComplete")
+        NotificationCenter.observe(customNotification) { _ in
+            print("Sign in complete")
+        }
+    }
+}
+
+NotificationCenter.post(AppNotification.onScreenshot)
+```
+
+`Notification.Name` also conforms to `PovioNotificationRepresentable`, so UIKit system
+notifications can be used directly:
+
+```swift
+NotificationCenter.publisher(for: UIApplication.didBecomeActiveNotification)
+```
+
+Or use the built-in typed enum:
+
+```swift
+NotificationCenter.publisher(for: AppNotification.onAppResume)
+NotificationCenter.observe(AppNotification.keyboardWillShow) { _ in
+    print("Keyboard will show")
+}
+```

--- a/Resources/Core/README.md
+++ b/Resources/Core/README.md
@@ -21,6 +21,7 @@ Core package includes essentials needed for the development and for other packag
 | [DispatchTimeInterval](/Sources/Core/Extensions/Foundation/DispatchTimeInterval+PovioKit.swift) | | |
 | [Double](/Sources/Core/Extensions/Foundation/Double+PovioKit.swift) | | |
 | [Encodable](/Sources/Core/Extensions/Foundation/Encodable+PovioKit.swift) | | |
+| [NotificationCenter](/Sources/Core/Extensions/Foundation/NotificationCenter+PovioKit.swift) ([Usage](Extensions/NotificationCenter+PovioKit.md)) | | |
 | [Optional](/Sources/Core/Extensions/Foundation/Optional+PovioKit.swift) | | |
 | [Result](/Sources/Core/Extensions/Foundation/Result+PovioKit.swift) | | |
 | [String](/Sources/Core/Extensions/Foundation/String+PovioKit.swift) | | |

--- a/Sources/Core/Extensions/Foundation/NotificationCenter+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/NotificationCenter+PovioKit.swift
@@ -1,0 +1,112 @@
+//
+//  NotificationCenter+PovioKit.swift
+//  PovioKit
+//
+//  Created by Povio Team on 14/04/2026.
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import Combine
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// A type that can be represented as `Notification.Name`.
+public protocol PovioNotificationRepresentable {
+  var name: Notification.Name { get }
+}
+
+/// Unified app notification entrypoint.
+public enum AppNotification: Hashable, PovioNotificationRepresentable {
+#if canImport(UIKit)
+  case onAppResume
+  case onAppPause
+  case onScreenshot
+  case keyboardWillShow
+  case keyboardWillHide
+#endif
+  case deviceDidShake
+  case named(Notification.Name)
+  
+  /// Creates a custom notification from a raw notification name.
+  public static func named(_ rawName: String) -> Self {
+    .named(Notification.Name(rawName))
+  }
+  
+  public var name: Notification.Name {
+    switch self {
+#if canImport(UIKit)
+    case .onAppResume:
+      return UIApplication.willEnterForegroundNotification
+    case .onAppPause:
+      return UIApplication.didEnterBackgroundNotification
+    case .onScreenshot:
+      return UIApplication.userDidTakeScreenshotNotification
+    case .keyboardWillShow:
+      return UIResponder.keyboardWillShowNotification
+    case .keyboardWillHide:
+      return UIResponder.keyboardWillHideNotification
+#endif
+    case .deviceDidShake:
+      return Notification.Name("com.poviokit.notification.deviceDidShake")
+    case let .named(name):
+      return name
+    }
+  }
+}
+
+extension Notification.Name: PovioNotificationRepresentable {
+  public var name: Notification.Name { self }
+}
+
+public extension NotificationCenter {
+  static func post<N: PovioNotificationRepresentable>(_ notification: N, object: Any? = nil, userInfo: [AnyHashable: Any]? = nil) {
+    NotificationCenter.default.post(name: notification.name, object: object, userInfo: userInfo)
+  }
+  
+  @discardableResult
+  static func observe<N: PovioNotificationRepresentable>(
+    _ notification: N,
+    object: Any? = nil,
+    queue: OperationQueue? = .main,
+    callback: @escaping (Notification) -> Void
+  ) -> NSObjectProtocol {
+    NotificationCenter.default.addObserver(
+      forName: notification.name,
+      object: object,
+      queue: queue,
+      using: callback
+    )
+  }
+  
+  @discardableResult
+  static func observe<N: PovioNotificationRepresentable>(
+    _ notifications: [N],
+    object: Any? = nil,
+    queue: OperationQueue? = .main,
+    callback: @escaping (N, Notification) -> Void
+  ) -> [NSObjectProtocol] {
+    notifications.map { notification in
+      NotificationCenter.default.addObserver(
+        forName: notification.name,
+        object: object,
+        queue: queue
+      ) { observedNotification in
+        callback(notification, observedNotification)
+      }
+    }
+  }
+  
+  static func publisher<N: PovioNotificationRepresentable>(for notification: N, object: AnyObject? = nil) -> NotificationCenter.Publisher {
+    NotificationCenter.default.publisher(for: notification.name, object: object)
+  }
+  
+  static func remove<N: PovioNotificationRepresentable>(_ observer: Any, for notification: N, object: Any? = nil) {
+    NotificationCenter.default.removeObserver(observer, name: notification.name, object: object)
+  }
+  
+  static func remove(_ observer: Any) {
+    NotificationCenter.default.removeObserver(observer)
+  }
+}

--- a/Sources/UI/SwiftUI/View Modifiers/DeviceShakeViewModifier.swift
+++ b/Sources/UI/SwiftUI/View Modifiers/DeviceShakeViewModifier.swift
@@ -1,0 +1,28 @@
+//
+//  DeviceShakeViewModifier.swift
+//  PovioKit
+//
+//  Created by Borut Tomazin on 14/04/2026.
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import SwiftUI
+import PovioKitCore
+
+struct DeviceShakeViewModifier: ViewModifier {
+  let action: () -> Void
+  
+  func body(content: Content) -> some View {
+    content
+      .onAppear()
+      .onReceive(NotificationCenter.publisher(for: AppNotification.deviceDidShake)) { _ in
+        action()
+      }
+  }
+}
+
+public extension View {
+  func onShake(perform action: @escaping () -> Void) -> some View {
+    modifier(DeviceShakeViewModifier(action: action))
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a typed notification layer in `PovioKitCore` and introduces a SwiftUI modifier for reacting to device shake events in `PovioKitUI`.

## What Changed

- Added `NotificationCenter+PovioKit` in Core:
  - Introduced `PovioNotificationRepresentable`
  - Added `AppNotification` as a unified typed notification enum
  - Added convenience APIs on `NotificationCenter` for:
    - posting notifications
    - observing single/multiple notifications
    - creating Combine publishers
    - removing observers
- Added documentation for the new Core notification APIs:
  - `Resources/Core/Extensions/NotificationCenter+PovioKit.md`
  - linked from `Resources/Core/README.md`
- Added `DeviceShakeViewModifier` in UI:
  - Introduced `View.onShake(perform:)`
  - Uses `NotificationCenter.publisher(for: AppNotification.deviceDidShake)` to trigger callbacks

## Why

- Standardize notification usage behind typed APIs instead of scattered string-based names.
- Improve readability and discoverability for app/system notifications.
- Provide a simple SwiftUI hook (`onShake`) for shake-driven UX while keeping shake detection app-controlled via `AppNotification.deviceDidShake`.

## Notes

- `AppNotification.deviceDidShake` is intentionally app-emitted; apps are responsible for posting it when a shake is detected.