### PR TITLE
Async/Updates

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -1,0 +1,100 @@
+name: Docs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build-docs:
+    runs-on: macos-26-xlarge
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v5
+
+    - name: Load Latest Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
+    - name: Generate Static DocC Documentation
+      run: |
+        set -euo pipefail
+        SITE_DIR=".build/DocC/site"
+        mkdir -p "$SITE_DIR"
+
+        targets=(
+          PovioKitCore
+          PovioKitUtilities
+          PovioKitAsync
+          PovioKitUIKit
+          PovioKitSwiftUI
+          PovioKitAppKit
+        )
+
+        for target in "${targets[@]}"; do
+          target_output="$SITE_DIR/$target"
+          mkdir -p "$target_output"
+          swift package \
+            --allow-writing-to-directory "$target_output" \
+            generate-documentation \
+            --target "$target" \
+            --disable-indexing \
+            --transform-for-static-hosting \
+            --hosting-base-path "PovioKit/$target" \
+            --output-path "$target_output"
+        done
+
+        cat > "$SITE_DIR/index.html" <<'EOF'
+        <!doctype html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <title>PovioKit Documentation</title>
+          <style>
+            body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem; }
+            ul { line-height: 1.8; }
+          </style>
+        </head>
+        <body>
+          <h1>PovioKit Documentation</h1>
+          <ul>
+            <li><a href="./PovioKitCore/documentation/poviokitcore/">PovioKitCore</a></li>
+            <li><a href="./PovioKitUtilities/documentation/poviokitutilities/">PovioKitUtilities</a></li>
+            <li><a href="./PovioKitAsync/documentation/poviokitasync/">PovioKitAsync</a></li>
+            <li><a href="./PovioKitUIKit/documentation/poviokituikit/">PovioKitUIKit</a></li>
+            <li><a href="./PovioKitSwiftUI/documentation/poviokitswiftui/">PovioKitSwiftUI</a></li>
+            <li><a href="./PovioKitAppKit/documentation/poviokitappkit/">PovioKitAppKit</a></li>
+          </ul>
+        </body>
+        </html>
+        EOF
+
+    - name: Upload Docs Artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: .build/DocC/site
+
+  deploy-docs:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-docs
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/SPM.yml
+++ b/.github/workflows/SPM.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * 6' # run every Sunday midnight
 
+permissions:
+  contents: read
+
 jobs:
   swiftpm:
     runs-on: macos-13

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Tests:
+  Tests-iOS:
     runs-on: macos-26-xlarge
     steps:
     - name: Cancel previous jobs
@@ -28,3 +28,20 @@ jobs:
 
     - name: Run tests
       run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -destination 'name=iPhone 17 Pro,OS=26.1' -scheme 'PovioKit-Package' | xcpretty      
+
+  Tests-macOS:
+    runs-on: macos-26-xlarge
+    steps:
+    - name: Cancel previous jobs
+      uses: styfle/cancel-workflow-action@0.12.1
+
+    - name: Checkout Repository
+      uses: actions/checkout@v5
+
+    - name: Load Latest Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
+    - name: Run tests
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test -destination 'platform=macOS' -scheme 'PovioKit-Package' | xcpretty

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -8,6 +8,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   Tests-iOS:
     runs-on: macos-26-xlarge

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -44,4 +44,4 @@ jobs:
         xcode-version: latest-stable
 
     - name: Run tests
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test -destination 'platform=macOS' -scheme 'PovioKit-Package' | xcpretty
+      run: env NSUnbufferedIO=YES swift test --no-parallel

--- a/.swiftpm/xcode/xcshareddata/xcschemes/PovioKit-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/PovioKit-Package.xcscheme
@@ -9,62 +9,6 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "PovioKit"
-               BuildableName = "PovioKit"
-               BlueprintName = "PovioKit"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "PovioKitNetworking"
-               BuildableName = "PovioKitNetworking"
-               BlueprintName = "PovioKitNetworking"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "PovioKitPromise"
-               BuildableName = "PovioKitPromise"
-               BlueprintName = "PovioKitPromise"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "PovioKitUI"
-               BuildableName = "PovioKitUI"
-               BlueprintName = "PovioKitUI"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">
@@ -79,56 +23,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "PovioKitAuthApple"
-               BuildableName = "PovioKitAuthApple"
-               BlueprintName = "PovioKitAuthApple"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "PovioKitAuthCore"
-               BuildableName = "PovioKitAuthCore"
-               BlueprintName = "PovioKitAuthCore"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "PovioKitAuthFacebook"
-               BuildableName = "PovioKitAuthFacebook"
-               BlueprintName = "PovioKitAuthFacebook"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "PovioKitAuthGoogle"
-               BuildableName = "PovioKitAuthGoogle"
-               BlueprintName = "PovioKitAuthGoogle"
+               BlueprintIdentifier = "PovioKitAppKit"
+               BuildableName = "PovioKitAppKit"
+               BlueprintName = "PovioKitAppKit"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -245,9 +147,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "PovioKit"
-            BuildableName = "PovioKit"
-            BlueprintName = "PovioKit"
+            BlueprintIdentifier = "PovioKitCore"
+            BuildableName = "PovioKitCore"
+            BlueprintName = "PovioKitCore"
             ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>

--- a/Collections/poviokit.json
+++ b/Collections/poviokit.json
@@ -17,7 +17,7 @@
         "uikit",
         "appkit"
       ],
-      "readmeURL": "https://raw.githubusercontent.com/povio/PovioKit/develop/README.md",
+      "readmeURL": "https://raw.githubusercontent.com/povio/PovioKit/main/README.md",
       "summary": "A modular library collection for Swift development, providing Core utilities, UIKit/SwiftUI/AppKit components, and async/await helpers.",
       "url": "https://github.com/povio/PovioKit.git",
       "versions": [

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,15 @@
 ## Migration Guides
 
+### Migration from versions < 6.3.0
+* [Async] `PovioKitAsync` was significantly expanded with:
+  * `AsyncDebounceSequence` (`debounce`) for bursty input control.
+  * Retry improvements: `shouldRetry` predicate and jitter support in `AsyncRetryPolicy`.
+  * `race` helpers for first-completed operation semantics.
+  * `AsyncSemaphore` for bounded async concurrency.
+  * `TaskCoalescer` for deduplicating in-flight keyed work.
+  * `AsyncTickerSequence` for interval-based async ticks.
+* [Async] Existing `retry` calls remain source-compatible. New `shouldRetry` parameter defaults to retrying all errors.
+
 ### Migration from versions < 6.2.0
 * [Package] Added a separate `PovioKitAppKit` product. If you need AppKit APIs, include this product in your package selection.
 * [Core] `Kingfisher` is no longer a transitive dependency of `PovioKitCore`.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -9,7 +9,7 @@
 * We dropped support for iOS 13, 14 and 15. Supported versions are 16+.
 * We dropped support for macOS 12. Supported versions are 13+.
 * [Networking] In order to continue using PovioKitNetworking, you'll need to install it as a [separate dependency](https://github.com/povio/PovioKitNetworking).
-* [PromiseKit] In order to continue using PovioKitPromise, you'll need to install is as a [separate dependency](https://github.com/povio/PovioKitNetworking).
+* [PromiseKit] In order to continue using PovioKitPromise, you'll need to install it as a [separate dependency](https://github.com/povio/PovioKitNetworking).
 
 ### Migration from versions < 5.0.0
 * [UI] Removed `ActionButton`, `ProfileImageView`.
@@ -19,7 +19,7 @@
 * [UI] PovioKitUI package has been replaced by PovioKitUIKit and/or PovioKitSwiftUI. Replace depending on the type of UI code you were depending on.
 
 ### Migration from versions < 3.0.0
-* [Auth] All Auth products are removed from the PovioKit package and effectivelly moved to a standalone repo https://github.com/poviolabs/PovioKitAuth. In order to continue using Auth products, install the new package `PovioKitAuth` package from the given repo url. 
+* [Auth] All Auth products are removed from the PovioKit package and effectively moved to a standalone repo https://github.com/povio/PovioKitAuth. In order to continue using Auth products, install the new `PovioKitAuth` package from the given repo URL.
 
 ### Migration from versions < 2.3.0
 * [Core] The main package was renamed from `PovioKit` to `PovioKitCore`. You'll need to make a few changes in order to make this work:
@@ -31,16 +31,16 @@
 * [Core] Deprecated DataSource protocols and SignInWithApple utility have been removed.
 
 ### Migration from versions < 2.0.0
-* [Networking] File `OAuthRequestInterceptor` has been completely removed due to some critical issues. We encourage you to migrate to Alamofire's `Authenticator` protocol. Instructions can be found [here](Resources/Networking/AlamofireNetworkClient#oauth). Deprecated methods have also been removed.
+* [Networking] File `OAuthRequestInterceptor` has been completely removed due to some critical issues. We encourage you to migrate to Alamofire's `Authenticator` protocol. See the networking package documentation at https://github.com/povio/PovioKitNetworking for migration details. Deprecated methods have also been removed.
 * [Package] The minimum supported version of iOS is 13. If you still support iOS 12, please evaluate this update.
 * [Core] DataSource protocols have been deprecated in favor or diffable data source.
 * [UI] Removed deprecated methods.
 
 ### Migration from versions < 1.4.1
-* [Networking] File `OAuthRequestInterceptor` has been deprecated due to some critical issues. We encourage you to migrate to Alamofire's `Authenticator` protocol. Instructions can be found [here](Resources/Networking/AlamofireNetworkClient#oauth).
+* [Networking] File `OAuthRequestInterceptor` has been deprecated due to some critical issues. We encourage you to migrate to Alamofire's `Authenticator` protocol. See https://github.com/povio/PovioKitNetworking for current guidance.
 
 ### Migration from versions < 1.4.0
-* [UI] New product `PovioKitUI` is introduced. In order to use it, please re-intall dependency and select it from product selection list.
+* [UI] New product `PovioKitUI` is introduced. In order to use it, please re-install dependency and select it from product selection list.
 * [Networking] Method `asJson` was marked as deprecated. Please stop using it soon.
 * [PromiseKit] Removed deprecated methods.
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -8,6 +8,24 @@
         "revision" : "c152c1915f60c51e4afa0752656993ee5b3c63db",
         "version" : "8.8.1"
       }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
+        "version" : "1.4.6"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -71,6 +71,7 @@ let package = Package(
         "PovioKitCore",
         "PovioKitUIKit",
         "PovioKitSwiftUI",
+        "PovioKitAppKit",
         "PovioKitUtilities",
         "PovioKitAsync",
       ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
     .library(name: "PovioKitAsync", targets: ["PovioKitAsync"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/onevcat/Kingfisher", .upToNextMajor(from: "8.0.0"))
+    .package(url: "https://github.com/onevcat/Kingfisher", .upToNextMajor(from: "8.0.0")),
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.5")
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-    <a href="https://swiftpackageregistry.com/poviolabs/PovioKit" alt="Package">
+    <a href="https://swiftpackageregistry.com/povio/PovioKit" alt="Package">
         <img src="https://img.shields.io/badge/SPM-Swift-lightgrey.svg" />
     </a>
     <a href="https://www.swift.org" alt="Swift">
@@ -12,8 +12,8 @@
     <a href="./LICENSE" alt="License">
         <img src="https://img.shields.io/badge/Licence-MIT-red.svg" />
     </a>
-    <a href="https://github.com/poviolabs/PovioKit/actions/workflows/Tests.yml" alt="Tests Status">
-        <img src="https://github.com/poviolabs/PovioKit/actions/workflows/Tests.yml/badge.svg" />
+    <a href="https://github.com/povio/PovioKit/actions/workflows/Tests.yml" alt="Tests Status">
+        <img src="https://github.com/povio/PovioKit/actions/workflows/Tests.yml/badge.svg" />
     </a>
 </p>
 
@@ -26,11 +26,22 @@
 | [Core](Resources/Core) | [Utilities](Resources/Utilities) | [Async](Resources/Async) | [UIKit](Resources/UI/UIKit) | [SwiftUI](Resources/UI/SwiftUI) | [AppKit](Resources/UI/AppKit) |
 | :-: | :-: | :-: | :-: | :-: | :-: |
 
+## Platform Support
+
+| Product | iOS 16+ | macOS 13+ | Notes |
+| :- | :-: | :-: | :- |
+| `PovioKitCore` | Yes | Yes | Foundation-first shared primitives and extensions. |
+| `PovioKitUtilities` | Yes | Yes | Some utilities are platform-specific; see module docs. |
+| `PovioKitAsync` | Yes | Yes | Async/await utilities. |
+| `PovioKitSwiftUI` | Yes | Yes | SwiftUI-specific components. |
+| `PovioKitUIKit` | Yes | No | UIKit-only APIs. |
+| `PovioKitAppKit` | No | Yes | AppKit-only APIs. |
+
 ## Installation
 
 ### Swift Package Manager
 - In Xcode, click `File` -> `Add Package Dependencies...`  
-- Insert `https://github.com/poviolabs/PovioKit` in the Search field.
+- Insert `https://github.com/povio/PovioKit` in the Search field.
 - Select a desired `Dependency Rule`. Usually "Up to Next Major Version" with "6.0.0".
 - Select "Add Package" button and check one or all given products from the list:
   - *PovioKitCore* (core library)
@@ -48,12 +59,12 @@ Discover all Povio packages in one place using our Swift Package Collection!
 **Add via Xcode:**
 1. Open Xcode → Settings → Swift Packages
 2. Click the **+** button
-3. Enter: `https://raw.githubusercontent.com/povio/PovioKit/master/Collections/poviokit.json`
+3. Enter: `https://raw.githubusercontent.com/povio/PovioKit/main/Collections/poviokit.json`
 4. Click **Add**
 
 **Add via Command Line:**
 ```bash
-swift package-collection add https://raw.githubusercontent.com/povio/PovioKit/master/Collections/poviokit.json
+swift package-collection add https://raw.githubusercontent.com/povio/PovioKit/main/Collections/poviokit.json
 ```
 
 The collection includes:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@
 | `PovioKitUIKit` | Yes | No | UIKit-only APIs. |
 | `PovioKitAppKit` | No | Yes | AppKit-only APIs. |
 
+## Documentation
+
+- API documentation is generated with DocC and published through GitHub Pages.
+- Published docs root: `https://povio.github.io/PovioKit/`
+- To build docs locally:
+
+```bash
+xcodebuild docbuild -destination 'platform=macOS' -scheme 'PovioKit-Package'
+```
+
 ## Installation
 
 ### Swift Package Manager

--- a/Resources/Async/README.md
+++ b/Resources/Async/README.md
@@ -2,7 +2,138 @@
 
 A package that includes async components and tools.
 
+- [Recipes](Recipes.md): practical composition patterns for production workflows.
+
 ### Components
 | Component | Description |
 | :--- | :--- |
 | [AsyncThrottleSequence](/Sources/Async/AsyncThrottleSequence.swift) | A wrapper around an `AsyncSequence` that introduces a delay between tasks to control the rate at which elements are emitted. |
+| [AsyncDebounceSequence](/Sources/Async/AsyncDebounceSequence.swift) | A wrapper around an `AsyncSequence` that emits only the latest element after a quiet period. |
+| [retry(policy:clock:operation:)](/Sources/Async/AsyncUtilities.swift) | Retries an async operation with configurable attempts and exponential backoff. |
+| [withTimeout(_:clock:operation:)](/Sources/Async/AsyncUtilities.swift) | Runs an async operation with a timeout and throws if the deadline is exceeded. |
+| [race](/Sources/Async/AsyncUtilities.swift) | Runs multiple operations in parallel and returns the first completed result. |
+| [makeAsyncStream](/Sources/Async/AsyncUtilities.swift) | Creates an `AsyncStream` together with its continuation for callback bridging. |
+| [makeAsyncThrowingStream](/Sources/Async/AsyncUtilities.swift) | Creates an `AsyncThrowingStream` and continuation pair with typed failure. |
+| [AsyncSemaphore](/Sources/Async/AsyncSemaphore.swift) | Limits how many async operations can run at the same time. |
+| [TaskCoalescer](/Sources/Async/TaskCoalescer.swift) | Deduplicates in-flight operations by key and shares a single task result. |
+| [AsyncTickerSequence](/Sources/Async/AsyncTickerSequence.swift) | Emits periodic ticks at a fixed interval. |
+
+### Examples
+
+#### AsyncThrottleSequence
+
+```swift
+let throttledSearch = SearchAsyncSequence()
+  .throttle(clock: .suspending, delayBetweenTasks: .milliseconds(400))
+  .makeAsyncIterator()
+
+let result = try await throttledSearch.next()
+```
+
+#### AsyncDebounceSequence
+
+```swift
+for try await query in userInputSequence.debounce(
+  clock: .suspending,
+  delayBetweenElements: .milliseconds(300)
+) {
+  try await searchService.search(query: query)
+}
+```
+
+#### retry(policy:clock:operation:)
+
+```swift
+let profile = try await retry(
+  policy: .init(
+    maxAttempts: 3,
+    initialDelay: .milliseconds(200),
+    backoffFactor: 2,
+    jitter: .milliseconds(50)
+  ),
+  shouldRetry: { error in
+    (error as? URLError)?.code != .userAuthenticationRequired
+  }
+) {
+  try await apiClient.fetchProfile()
+}
+```
+
+#### withTimeout(_:clock:operation:)
+
+```swift
+let data = try await withTimeout(.seconds(2)) {
+  try await networkClient.requestData()
+}
+```
+
+#### race
+
+```swift
+let response = try await race(
+  { try await cacheClient.read() },
+  { try await apiClient.request() }
+)
+```
+
+#### makeAsyncStream
+
+```swift
+let pipe = makeAsyncStream() as AsyncStreamPipe<String>
+callbackSource.onEvent = { event in pipe.continuation.yield(event) }
+
+for await event in pipe.stream {
+  print(event)
+}
+```
+
+#### makeAsyncThrowingStream
+
+```swift
+let pipe = makeAsyncThrowingStream() as AsyncThrowingStreamPipe<Data>
+socket.onMessage = { message in pipe.continuation.yield(message) }
+socket.onError = { error in pipe.continuation.finish(throwing: error) }
+
+for try await message in pipe.stream {
+  print(message)
+}
+```
+
+#### AsyncSemaphore
+
+```swift
+let semaphore = AsyncSemaphore(value: 3)
+
+try await withThrowingTaskGroup(of: Void.self) { group in
+  for imageURL in urls {
+    group.addTask {
+      try await semaphore.withPermit {
+        try await imageClient.download(url: imageURL)
+      }
+    }
+  }
+  try await group.waitForAll()
+}
+```
+
+#### TaskCoalescer
+
+```swift
+let coalescer = TaskCoalescer<String, User>()
+
+let user = try await coalescer.value(for: "user_42") {
+  try await apiClient.fetchUser(id: "user_42")
+}
+```
+
+#### AsyncTickerSequence
+
+```swift
+let ticker = AsyncTickerSequence(
+  clock: ContinuousClock(),
+  interval: .seconds(1)
+)
+
+var iterator = ticker.makeAsyncIterator()
+let firstTick = try await iterator.next()
+```

--- a/Resources/Async/Recipes.md
+++ b/Resources/Async/Recipes.md
@@ -1,0 +1,102 @@
+# PovioKitAsync Recipes
+
+Real-world patterns that combine multiple async utilities.
+
+## Debounced Search With Timeout And Retry
+
+```swift
+for try await query in queryStream.debounce(
+  clock: .suspending,
+  delayBetweenElements: .milliseconds(300)
+) {
+  let result = try await retry(
+    policy: .init(
+      maxAttempts: 3,
+      initialDelay: .milliseconds(200),
+      backoffFactor: 2,
+      jitter: .milliseconds(60)
+    )
+  ) {
+    try await withTimeout(.seconds(2)) {
+      try await searchClient.search(query: query)
+    }
+  }
+
+  await MainActor.run {
+    viewModel.items = result.items
+  }
+}
+```
+
+## Cache-First Race Strategy
+
+```swift
+let response = try await race(
+  { try await cacheClient.readProfile() },
+  { try await apiClient.fetchProfile() }
+)
+```
+
+Use this when either source is acceptable and fastest completion wins.
+
+## Bounded Parallel Downloads
+
+```swift
+let semaphore = AsyncSemaphore(value: 3)
+
+try await withThrowingTaskGroup(of: Void.self) { group in
+  for url in urls {
+    group.addTask {
+      try await semaphore.withPermit {
+        try await downloadClient.fetch(url: url)
+      }
+    }
+  }
+  try await group.waitForAll()
+}
+```
+
+## Coalesced In-Flight Requests
+
+```swift
+let coalescer = TaskCoalescer<String, User>()
+
+func loadUser(id: String) async throws -> User {
+  try await coalescer.value(for: id) {
+    try await apiClient.fetchUser(id: id)
+  }
+}
+```
+
+If multiple callers request the same `id` concurrently, only one network call runs.
+
+## Callback Bridge To AsyncStream
+
+```swift
+let events = makeAsyncThrowingStream() as AsyncThrowingStreamPipe<Event>
+
+sdk.onEvent = { event in
+  events.continuation.yield(event)
+}
+sdk.onError = { error in
+  events.continuation.finish(throwing: error)
+}
+
+for try await event in events.stream {
+  handle(event)
+}
+```
+
+## Polling / Heartbeat Loop
+
+```swift
+let ticker = AsyncTickerSequence(
+  clock: ContinuousClock(),
+  interval: .seconds(5),
+  initialDelay: .seconds(1)
+)
+
+for try await _ in ticker {
+  try await syncClient.refresh()
+}
+```

--- a/Sources/Async/AsyncDebounceSequence.swift
+++ b/Sources/Async/AsyncDebounceSequence.swift
@@ -1,0 +1,121 @@
+//
+//  AsyncDebounceSequence.swift
+//  PovioKit
+//
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import Foundation
+
+/// `AsyncDebounceSequence` emits the latest element only after a quiet period.
+///
+/// When multiple values arrive within `delayBetweenElements`, earlier values are
+/// discarded and only the newest value is emitted.
+public struct AsyncDebounceSequence<BaseSequence: AsyncSequence, C: Clock> {
+  let baseSequence: BaseSequence
+  let clock: C
+  let delayBetweenElements: C.Duration
+
+  public init(
+    _ baseSequence: BaseSequence,
+    clock: C,
+    delayBetweenElements: C.Duration
+  ) {
+    self.baseSequence = baseSequence
+    self.clock = clock
+    self.delayBetweenElements = delayBetweenElements
+  }
+}
+
+extension AsyncDebounceSequence: AsyncSequence where C.Duration == Duration {
+  public typealias Element = BaseSequence.Element
+
+  public final class Iterator: AsyncIteratorProtocol {
+    typealias PendingValue = (value: Element, timestamp: C.Instant)
+
+    var baseIterator: BaseSequence.AsyncIterator
+    let clock: C
+    let delayBetweenElements: Duration
+    var hasEnded = false
+    var pending: PendingValue?
+
+    init(
+      baseIterator: BaseSequence.AsyncIterator,
+      clock: C,
+      delayBetweenElements: Duration
+    ) {
+      self.baseIterator = baseIterator
+      self.clock = clock
+      self.delayBetweenElements = delayBetweenElements
+    }
+
+    public func next() async throws -> Element? {
+      if hasEnded {
+        return nil
+      }
+
+      var latest: Element
+      var latestTimestamp: C.Instant
+
+      if let pending {
+        latest = pending.value
+        latestTimestamp = pending.timestamp
+        self.pending = nil
+      } else {
+        guard let first = try await baseIterator.next() else {
+          hasEnded = true
+          return nil
+        }
+        latest = first
+        latestTimestamp = clock.now
+      }
+
+      while true {
+        guard let nextValue = try await baseIterator.next() else {
+          // End of source: wait out debounce window before emitting latest.
+          let emitAt = latestTimestamp.advanced(by: delayBetweenElements)
+          if emitAt > clock.now {
+            try await Task.sleep(until: emitAt, clock: clock)
+          }
+          hasEnded = true
+          return latest
+        }
+
+        let now = clock.now
+        if latestTimestamp.duration(to: now) >= delayBetweenElements {
+          pending = (nextValue, now)
+          return latest
+        }
+
+        latest = nextValue
+        latestTimestamp = now
+      }
+    }
+  }
+
+  public func makeAsyncIterator() -> Iterator {
+    .init(
+      baseIterator: baseSequence.makeAsyncIterator(),
+      clock: clock,
+      delayBetweenElements: delayBetweenElements
+    )
+  }
+}
+
+public extension AsyncSequence {
+  /// Creates a debounced wrapper around this sequence.
+  ///
+  /// ## Example
+  /// ```swift
+  /// let debounced = queryChanges.debounce(
+  ///   clock: .suspending,
+  ///   delayBetweenElements: .milliseconds(350)
+  /// )
+  /// ```
+  func debounce<C: Clock>(
+    clock: C,
+    delayBetweenElements: C.Duration
+  ) -> AsyncDebounceSequence<Self, C> {
+    .init(self, clock: clock, delayBetweenElements: delayBetweenElements)
+  }
+}

--- a/Sources/Async/AsyncSemaphore.swift
+++ b/Sources/Async/AsyncSemaphore.swift
@@ -1,0 +1,81 @@
+//
+//  AsyncSemaphore.swift
+//  PovioKit
+//
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A lightweight semaphore for limiting concurrent async work.
+///
+/// ## Example
+/// ```swift
+/// let semaphore = AsyncSemaphore(value: 3)
+///
+/// try await withThrowingTaskGroup(of: Void.self) { group in
+///   for task in tasks {
+///     group.addTask {
+///       try await semaphore.withPermit {
+///         try await task.run()
+///       }
+///     }
+///   }
+///   try await group.waitForAll()
+/// }
+/// ```
+public final class AsyncSemaphore: @unchecked Sendable {
+  private let lock = NSLock()
+  private var permits: Int
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  public init(value: Int) {
+    self.permits = max(0, value)
+  }
+
+  public func acquire() async {
+    let shouldSuspend = lock.withLock {
+      if permits > 0 {
+        permits -= 1
+        return false
+      }
+      return true
+    }
+
+    if shouldSuspend {
+      await withCheckedContinuation { continuation in
+        lock.withLock {
+          waiters.append(continuation)
+        }
+      }
+    }
+  }
+
+  public func release() {
+    let waiter = lock.withLock { () -> CheckedContinuation<Void, Never>? in
+      if !waiters.isEmpty {
+        return waiters.removeFirst()
+      }
+      permits += 1
+      return nil
+    }
+
+    waiter?.resume()
+  }
+
+  public func withPermit<R>(
+    _ operation: @escaping @Sendable () async throws -> R
+  ) async rethrows -> R {
+    await acquire()
+    defer { release() }
+    return try await operation()
+  }
+}
+
+private extension NSLock {
+  func withLock<R>(_ operation: () throws -> R) rethrows -> R {
+    lock()
+    defer { unlock() }
+    return try operation()
+  }
+}

--- a/Sources/Async/AsyncTickerSequence.swift
+++ b/Sources/Async/AsyncTickerSequence.swift
@@ -1,0 +1,67 @@
+//
+//  AsyncTickerSequence.swift
+//  PovioKit
+//
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An infinite sequence that emits timestamps at a fixed interval.
+///
+/// ## Example
+/// ```swift
+/// let ticker = AsyncTickerSequence(
+///   clock: ContinuousClock(),
+///   interval: .seconds(1)
+/// )
+///
+/// var iterator = ticker.makeAsyncIterator()
+/// let firstTick = try await iterator.next()
+/// ```
+public struct AsyncTickerSequence<C: Clock> where C.Duration == Duration {
+  let clock: C
+  let interval: Duration
+  let initialDelay: Duration
+
+  public init(
+    clock: C,
+    interval: Duration,
+    initialDelay: Duration = .zero
+  ) {
+    self.clock = clock
+    self.interval = Swift.max(.zero, interval)
+    self.initialDelay = Swift.max(.zero, initialDelay)
+  }
+}
+
+extension AsyncTickerSequence: AsyncSequence {
+  public typealias Element = C.Instant
+
+  public struct Iterator: AsyncIteratorProtocol {
+    let clock: C
+    let interval: Duration
+    var nextTick: C.Instant
+
+    init(clock: C, interval: Duration, initialDelay: Duration) {
+      self.clock = clock
+      self.interval = interval
+      self.nextTick = clock.now.advanced(by: initialDelay)
+    }
+
+    public mutating func next() async throws -> C.Instant? {
+      try await Task.sleep(until: nextTick, clock: clock)
+      let emittedTick = nextTick
+      nextTick = emittedTick.advanced(by: interval)
+      return emittedTick
+    }
+  }
+
+  public func makeAsyncIterator() -> Iterator {
+    .init(
+      clock: clock,
+      interval: interval,
+      initialDelay: initialDelay
+    )
+  }
+}

--- a/Sources/Async/AsyncUtilities.swift
+++ b/Sources/Async/AsyncUtilities.swift
@@ -1,0 +1,340 @@
+//
+//  AsyncUtilities.swift
+//  PovioKit
+//
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Error thrown by timeout helpers when the configured deadline is reached.
+public enum AsyncTimeoutError: Error, Equatable {
+  case timedOut
+}
+
+/// Configuration used by ``retry(policy:clock:operation:)``.
+///
+/// ## Example
+/// ```swift
+/// let policy = AsyncRetryPolicy(
+///   maxAttempts: 4,
+///   initialDelay: .milliseconds(200),
+///   backoffFactor: 2,
+///   maxDelay: .seconds(2)
+/// )
+/// ```
+public struct AsyncRetryPolicy: Equatable, Sendable {
+  /// Total number of attempts, including the first one.
+  public let maxAttempts: Int
+  /// Delay before the first retry attempt.
+  public let initialDelay: Duration
+  /// Integer backoff factor applied after every failed attempt.
+  public let backoffFactor: Int
+  /// Optional maximum delay cap for backoff growth.
+  public let maxDelay: Duration?
+  /// Additional random delay in `[0, jitter]` added before each retry.
+  public let jitter: Duration
+
+  public init(
+    maxAttempts: Int = 3,
+    initialDelay: Duration = .zero,
+    backoffFactor: Int = 1,
+    maxDelay: Duration? = nil,
+    jitter: Duration = .zero
+  ) {
+    self.maxAttempts = max(1, maxAttempts)
+    self.initialDelay = max(.zero, initialDelay)
+    self.backoffFactor = max(1, backoffFactor)
+    if let maxDelay {
+      self.maxDelay = max(.zero, maxDelay)
+    } else {
+      self.maxDelay = nil
+    }
+    self.jitter = max(.zero, jitter)
+  }
+}
+
+/// Executes an async operation with retries according to the supplied policy.
+///
+/// - Parameters:
+///   - policy: Retry policy that controls attempts and delay growth.
+///   - clock: Clock used for sleeping between retries.
+///   - shouldRetry: Predicate that determines whether a thrown error is retryable.
+///   - operation: Async operation to execute.
+/// - Returns: Result returned by the first successful attempt.
+/// - Throws: Last error produced by the operation if all attempts fail.
+///
+/// ## Example
+/// ```swift
+/// let user = try await retry(
+///   policy: .init(maxAttempts: 3, initialDelay: .milliseconds(250), backoffFactor: 2),
+///   clock: .suspending
+/// ) {
+///   try await apiClient.fetchUser()
+/// }
+/// ```
+public func retry<R, C: Clock>(
+  policy: AsyncRetryPolicy = .init(),
+  clock: C,
+  shouldRetry: @escaping @Sendable (Error) -> Bool = { _ in true },
+  operation: @escaping @Sendable () async throws -> R
+) async throws -> R where C.Duration == Duration {
+  var nextDelay = policy.initialDelay
+
+  for attempt in 1 ... policy.maxAttempts {
+    do {
+      return try await operation()
+    } catch {
+      guard attempt < policy.maxAttempts, shouldRetry(error) else {
+        throw error
+      }
+
+      let jitterDelay = randomDuration(upTo: policy.jitter)
+      let totalDelay = nextDelay + jitterDelay
+      if totalDelay > .zero {
+        try await Task.sleep(until: clock.now.advanced(by: totalDelay), clock: clock)
+      }
+
+      let grownDelay = nextDelay * policy.backoffFactor
+      if let maxDelay = policy.maxDelay {
+        nextDelay = min(grownDelay, maxDelay)
+      } else {
+        nextDelay = grownDelay
+      }
+    }
+  }
+
+  // This line is unreachable because maxAttempts is always at least 1.
+  throw AsyncTimeoutError.timedOut
+}
+
+/// Executes an async operation with retries using `SuspendingClock`.
+///
+/// ## Example
+/// ```swift
+/// let config = try await retry(policy: .init(maxAttempts: 2)) {
+///   try await configService.load()
+/// }
+/// ```
+public func retry<R>(
+  policy: AsyncRetryPolicy = .init(),
+  shouldRetry: @escaping @Sendable (Error) -> Bool = { _ in true },
+  operation: @escaping @Sendable () async throws -> R
+) async throws -> R {
+  try await retry(policy: policy, clock: .suspending, shouldRetry: shouldRetry, operation: operation)
+}
+
+/// Runs an async operation and throws if it doesn't finish before the timeout.
+///
+/// - Parameters:
+///   - timeout: Maximum duration to wait for operation completion.
+///   - clock: Clock used to evaluate timeout.
+///   - operation: Async operation to run.
+/// - Returns: Result returned by the operation.
+/// - Throws: ``AsyncTimeoutError/timedOut`` when timeout elapses first.
+///
+/// ## Example
+/// ```swift
+/// let avatar = try await withTimeout(.seconds(2), clock: .suspending) {
+///   try await imageService.downloadAvatar()
+/// }
+/// ```
+public func withTimeout<R, C: Clock>(
+  _ timeout: C.Duration,
+  clock: C,
+  operation: @escaping @Sendable () async throws -> R
+) async throws -> R where C.Duration == Duration {
+  try await withThrowingTaskGroup(of: R.self) { group in
+    group.addTask {
+      try await operation()
+    }
+
+    group.addTask {
+      try await Task.sleep(until: clock.now.advanced(by: timeout), clock: clock)
+      throw AsyncTimeoutError.timedOut
+    }
+
+    guard let firstResult = try await group.next() else {
+      throw AsyncTimeoutError.timedOut
+    }
+
+    group.cancelAll()
+    return firstResult
+  }
+}
+
+/// Runs an async operation with timeout using `SuspendingClock`.
+///
+/// ## Example
+/// ```swift
+/// let value = try await withTimeout(.milliseconds(500)) {
+///   try await expensiveComputation()
+/// }
+/// ```
+public func withTimeout<R>(
+  _ timeout: Duration,
+  operation: @escaping @Sendable () async throws -> R
+) async throws -> R {
+  try await withTimeout(timeout, clock: .suspending, operation: operation)
+}
+
+/// Runs multiple operations concurrently and returns the first completed result.
+///
+/// Remaining operations are cancelled as soon as the first one completes.
+///
+/// ## Example
+/// ```swift
+/// let value = try await race(
+///   { try await cacheClient.fetch() },
+///   { try await networkClient.fetch() }
+/// )
+/// ```
+public func race<R>(
+  _ operations: (@Sendable () async throws -> R)...
+) async throws -> R {
+  try await race(operations)
+}
+
+/// Runs multiple operations concurrently and returns the first completed result.
+///
+/// Remaining operations are cancelled as soon as the first one completes.
+public func race<R>(
+  _ operations: [@Sendable () async throws -> R]
+) async throws -> R {
+  precondition(!operations.isEmpty, "At least one operation is required.")
+
+  return try await withThrowingTaskGroup(of: R.self) { group in
+    for operation in operations {
+      group.addTask {
+        try await operation()
+      }
+    }
+
+    guard let first = try await group.next() else {
+      throw AsyncTimeoutError.timedOut
+    }
+    group.cancelAll()
+    return first
+  }
+}
+
+/// Wrapper around an `AsyncStream` and its continuation.
+///
+/// You can use this type when you need both pieces to bridge callback-style APIs.
+public struct AsyncStreamPipe<Element>: Sendable where Element: Sendable {
+  public let stream: AsyncStream<Element>
+  public let continuation: AsyncStream<Element>.Continuation
+
+  public init(stream: AsyncStream<Element>, continuation: AsyncStream<Element>.Continuation) {
+    self.stream = stream
+    self.continuation = continuation
+  }
+}
+
+/// Wrapper around an `AsyncThrowingStream` and its continuation.
+///
+/// This type is useful when bridging callback-based APIs that may fail.
+public struct AsyncThrowingStreamPipe<Element>: Sendable where Element: Sendable {
+  public let stream: AsyncThrowingStream<Element, Error>
+  public let continuation: AsyncThrowingStream<Element, Error>.Continuation
+
+  public init(
+    stream: AsyncThrowingStream<Element, Error>,
+    continuation: AsyncThrowingStream<Element, Error>.Continuation
+  ) {
+    self.stream = stream
+    self.continuation = continuation
+  }
+}
+
+/// Creates a stream and continuation pair for callback-based event sources.
+///
+/// ## Example
+/// ```swift
+/// let pipe = makeAsyncStream() as AsyncStreamPipe<Int>
+///
+/// someEmitter.onValue = { value in
+///   pipe.continuation.yield(value)
+/// }
+///
+/// Task {
+///   for await value in pipe.stream {
+///     print("Received value:", value)
+///   }
+/// }
+/// ```
+public func makeAsyncStream<Element: Sendable>(
+  bufferingPolicy: AsyncStream<Element>.Continuation.BufferingPolicy = .unbounded
+) -> AsyncStreamPipe<Element> {
+  let state = NSLockValueBox<AsyncStream<Element>.Continuation?>(wrappedValue: nil)
+  let stream = AsyncStream<Element>(bufferingPolicy: bufferingPolicy) { continuation in
+    state.withLock { $0 = continuation }
+  }
+
+  return .init(stream: stream, continuation: state.withLock { $0! })
+}
+
+/// Creates a throwing stream and continuation pair for callback-based event sources.
+///
+/// ## Example
+/// ```swift
+/// let pipe = makeAsyncThrowingStream() as AsyncThrowingStreamPipe<Data>
+///
+/// socketClient.onData = { data in
+///   pipe.continuation.yield(data)
+/// }
+///
+/// socketClient.onError = { error in
+///   pipe.continuation.finish(throwing: error)
+/// }
+/// ```
+public func makeAsyncThrowingStream<Element: Sendable>(
+  bufferingPolicy: AsyncThrowingStream<Element, Error>.Continuation.BufferingPolicy = .unbounded
+) -> AsyncThrowingStreamPipe<Element> {
+  let state = NSLockValueBox<AsyncThrowingStream<Element, Error>.Continuation?>(wrappedValue: nil)
+  let stream = AsyncThrowingStream<Element, Error>(bufferingPolicy: bufferingPolicy) { continuation in
+    state.withLock { $0 = continuation }
+  }
+
+  return .init(stream: stream, continuation: state.withLock { $0! })
+}
+
+private final class NSLockValueBox<Value>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var value: Value
+
+  init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+
+  func withLock<R>(_ operation: (inout Value) throws -> R) rethrows -> R {
+    lock.lock()
+    defer { lock.unlock() }
+    return try operation(&value)
+  }
+}
+
+private func randomDuration(upTo maxDuration: Duration) -> Duration {
+  guard let maxNanos = durationToNanoseconds(maxDuration), maxNanos > 0 else {
+    return .zero
+  }
+
+  let randomNanos = Int64.random(in: 0 ... maxNanos)
+  return .nanoseconds(randomNanos)
+}
+
+private func durationToNanoseconds(_ duration: Duration) -> Int64? {
+  let (seconds, attoseconds) = duration.components
+  let attosecondsPerNanosecond: Int64 = 1_000_000_000
+  let (secondsInNanos, secondsOverflow) = seconds.multipliedReportingOverflow(by: 1_000_000_000)
+  if secondsOverflow {
+    return nil
+  }
+
+  let attosecondsInNanos = attoseconds / attosecondsPerNanosecond
+  let (totalNanos, nanosOverflow) = secondsInNanos.addingReportingOverflow(attosecondsInNanos)
+  if nanosOverflow {
+    return nil
+  }
+  return totalNanos
+}

--- a/Sources/Async/PovioKitAsync.docc/PovioKitAsync.md
+++ b/Sources/Async/PovioKitAsync.docc/PovioKitAsync.md
@@ -1,0 +1,9 @@
+# ``PovioKitAsync``
+
+Concurrency-focused helpers for async/await code paths.
+
+## Overview
+
+`PovioKitAsync` contains asynchronous sequence and throttling utilities intended to simplify coordination of concurrent tasks.
+
+This module contains concurrency tools for pacing and coordinating asynchronous workflows.

--- a/Sources/Async/PovioKitAsync.docc/PovioKitAsync.md
+++ b/Sources/Async/PovioKitAsync.docc/PovioKitAsync.md
@@ -7,3 +7,5 @@ Concurrency-focused helpers for async/await code paths.
 `PovioKitAsync` contains asynchronous sequence and throttling utilities intended to simplify coordination of concurrent tasks.
 
 This module contains concurrency tools for pacing and coordinating asynchronous workflows.
+It includes throttling and debouncing sequences, retries with jitter/backoff, timeout and race helpers,
+stream bridging utilities, bounded-concurrency control, task coalescing, and ticker sequences.

--- a/Sources/Async/TaskCoalescer.swift
+++ b/Sources/Async/TaskCoalescer.swift
@@ -1,0 +1,61 @@
+//
+//  TaskCoalescer.swift
+//  PovioKit
+//
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Deduplicates in-flight async work by key.
+///
+/// If multiple callers request the same key concurrently, only one operation
+/// runs and all callers await the same task result.
+///
+/// ## Example
+/// ```swift
+/// let coalescer = TaskCoalescer<String, User>()
+///
+/// let user = try await coalescer.value(for: "user-42") {
+///   try await apiClient.fetchUser(id: "user-42")
+/// }
+/// ```
+public actor TaskCoalescer<Key: Hashable & Sendable, Value: Sendable> {
+  private var tasks: [Key: Task<Value, Error>] = [:]
+
+  public init() {}
+
+  public func value(
+    for key: Key,
+    operation: @escaping @Sendable () async throws -> Value
+  ) async throws -> Value {
+    if let existingTask = tasks[key] {
+      return try await existingTask.value
+    }
+
+    let task = Task {
+      try await operation()
+    }
+    tasks[key] = task
+
+    do {
+      let value = try await task.value
+      tasks[key] = nil
+      return value
+    } catch {
+      tasks[key] = nil
+      throw error
+    }
+  }
+
+  public func cancelValue(for key: Key) {
+    tasks[key]?.cancel()
+    tasks[key] = nil
+  }
+
+  public func cancelAll() {
+    let pendingTasks = tasks.values
+    tasks.removeAll()
+    pendingTasks.forEach { $0.cancel() }
+  }
+}

--- a/Sources/Core/PovioKitCore.docc/PovioKitCore.md
+++ b/Sources/Core/PovioKitCore.docc/PovioKitCore.md
@@ -1,0 +1,9 @@
+# ``PovioKitCore``
+
+Core primitives, extensions, and shared building blocks used across PovioKit modules.
+
+## Overview
+
+`PovioKitCore` contains reusable foundation utilities and low-level helpers intended to stay lightweight and broadly applicable.
+
+This module is intended as the shared base layer for other PovioKit products.

--- a/Sources/UI/AppKit/PovioKitAppKit.docc/PovioKitAppKit.md
+++ b/Sources/UI/AppKit/PovioKitAppKit.docc/PovioKitAppKit.md
@@ -1,0 +1,9 @@
+# ``PovioKitAppKit``
+
+AppKit-focused APIs for macOS user interface layers.
+
+## Overview
+
+`PovioKitAppKit` contains macOS-specific view and window extensions for common rendering and capture workflows.
+
+Use this module when building AppKit-based macOS interfaces with PovioKit helpers.

--- a/Sources/UI/SwiftUI/PovioKitSwiftUI.docc/PovioKitSwiftUI.md
+++ b/Sources/UI/SwiftUI/PovioKitSwiftUI.docc/PovioKitSwiftUI.md
@@ -1,0 +1,9 @@
+# ``PovioKitSwiftUI``
+
+SwiftUI views, modifiers, and image-loading integrations.
+
+## Overview
+
+`PovioKitSwiftUI` offers composable SwiftUI utilities, including custom modifiers, view helpers, and Kingfisher-backed remote image building blocks.
+
+Use this module for SwiftUI-centric building blocks such as remote image rendering, image processors, and common view modifiers.

--- a/Sources/UI/SwiftUI/Views/RemoteImage/HEICImageProcessor.swift
+++ b/Sources/UI/SwiftUI/Views/RemoteImage/HEICImageProcessor.swift
@@ -49,8 +49,9 @@ public struct HEICImageProcessor: ImageProcessor {
   ///   - 0.7-0.8: Balanced (recommended)
   ///   - 0.5-0.6: High compression, smaller file size
   public init(compressionQuality: CGFloat = 0.8) {
-    self.compressionQuality = max(0.0, min(1.0, compressionQuality))
-    self.identifier = "com.povio.HEICImageProcessor(\(compressionQuality))"
+    let clampedQuality = max(0.0, min(1.0, compressionQuality))
+    self.compressionQuality = clampedQuality
+    self.identifier = "com.povio.HEICImageProcessor(\(clampedQuality))"
   }
   
   public func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {

--- a/Sources/UI/SwiftUI/Views/RemoteImage/JPEGImageProcessor.swift
+++ b/Sources/UI/SwiftUI/Views/RemoteImage/JPEGImageProcessor.swift
@@ -41,8 +41,9 @@ public struct JPEGImageProcessor: ImageProcessor {
   ///   - 0.7-0.8: Balanced (recommended)
   ///   - 0.5-0.6: High compression, smaller file size
   public init(compressionQuality: CGFloat = 0.8) {
-    self.compressionQuality = max(0.0, min(1.0, compressionQuality))
-    self.identifier = "com.povio.JPEGImageProcessor(\(compressionQuality))"
+    let clampedQuality = max(0.0, min(1.0, compressionQuality))
+    self.compressionQuality = clampedQuality
+    self.identifier = "com.povio.JPEGImageProcessor(\(clampedQuality))"
   }
   
   public func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {

--- a/Sources/UI/UIKit/PovioKitUIKit.docc/PovioKitUIKit.md
+++ b/Sources/UI/UIKit/PovioKitUIKit.docc/PovioKitUIKit.md
@@ -1,0 +1,9 @@
+# ``PovioKitUIKit``
+
+UIKit-specific components, views, and extensions.
+
+## Overview
+
+`PovioKitUIKit` provides iOS UIKit APIs for common view-layer patterns, convenience extensions, and reusable UI components.
+
+Use this module when building UIKit-based interfaces with PovioKit helpers.

--- a/Sources/Utilities/PovioKitUtilities.docc/PovioKitUtilities.md
+++ b/Sources/Utilities/PovioKitUtilities.docc/PovioKitUtilities.md
@@ -1,0 +1,9 @@
+# ``PovioKitUtilities``
+
+Higher-level utility components built on top of the PovioKitCore module.
+
+## Overview
+
+`PovioKitUtilities` bundles practical helpers for application workflows, data formatting, media handling, and reusable service abstractions.
+
+This module is focused on production-ready utilities commonly reused across apps.

--- a/Tests/Tests/Async/AsyncDebounceSequenceTests.swift
+++ b/Tests/Tests/Async/AsyncDebounceSequenceTests.swift
@@ -1,0 +1,65 @@
+//
+//  AsyncDebounceSequenceTests.swift
+//  PovioKit_Tests
+//
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import XCTest
+import PovioKitAsync
+
+final class AsyncDebounceSequenceTests: XCTestCase {
+  private struct DelayedValuesSequence: AsyncSequence {
+    typealias Element = Int
+
+    let values: [Int]
+    let delayBetweenValues: Duration
+
+    struct AsyncIterator: AsyncIteratorProtocol {
+      let values: [Int]
+      let delayBetweenValues: Duration
+      var index: Int = 0
+
+      mutating func next() async throws -> Int? {
+        guard index < values.count else { return nil }
+        try await Task.sleep(for: delayBetweenValues)
+        defer { index += 1 }
+        return values[index]
+      }
+    }
+
+    func makeAsyncIterator() -> AsyncIterator {
+      .init(values: values, delayBetweenValues: delayBetweenValues)
+    }
+  }
+
+  func testDebounceEmitsOnlyLatestValueFromBurst() async throws {
+    let sequence = DelayedValuesSequence(values: [1, 2, 3, 4], delayBetweenValues: .milliseconds(10))
+    let debounced = sequence.debounce(
+      clock: .suspending,
+      delayBetweenElements: .milliseconds(50)
+    )
+
+    let iterator = debounced.makeAsyncIterator()
+    let first = try await iterator.next()
+    let second = try await iterator.next()
+
+    XCTAssertEqual(first, 4)
+    XCTAssertNil(second)
+  }
+
+  func testDebounceEmitsAllWhenValuesAreSpacedOut() async throws {
+    let sequence = DelayedValuesSequence(values: [1, 2, 3], delayBetweenValues: .milliseconds(80))
+    let debounced = sequence.debounce(
+      clock: .suspending,
+      delayBetweenElements: .milliseconds(30)
+    )
+
+    var received: [Int] = []
+    for try await value in debounced {
+      received.append(value)
+    }
+
+    XCTAssertEqual(received, [1, 2, 3])
+  }
+}

--- a/Tests/Tests/Async/AsyncDebounceSequenceTests.swift
+++ b/Tests/Tests/Async/AsyncDebounceSequenceTests.swift
@@ -34,7 +34,7 @@ final class AsyncDebounceSequenceTests: XCTestCase {
   }
 
   func testDebounceEmitsOnlyLatestValueFromBurst() async throws {
-    let sequence = DelayedValuesSequence(values: [1, 2, 3, 4], delayBetweenValues: .milliseconds(10))
+    let sequence = DelayedValuesSequence(values: [1, 2, 3, 4], delayBetweenValues: .zero)
     let debounced = sequence.debounce(
       clock: .suspending,
       delayBetweenElements: .milliseconds(50)
@@ -49,10 +49,10 @@ final class AsyncDebounceSequenceTests: XCTestCase {
   }
 
   func testDebounceEmitsAllWhenValuesAreSpacedOut() async throws {
-    let sequence = DelayedValuesSequence(values: [1, 2, 3], delayBetweenValues: .milliseconds(80))
+    let sequence = DelayedValuesSequence(values: [1, 2, 3], delayBetweenValues: .milliseconds(200))
     let debounced = sequence.debounce(
       clock: .suspending,
-      delayBetweenElements: .milliseconds(30)
+      delayBetweenElements: .milliseconds(20)
     )
 
     var received: [Int] = []

--- a/Tests/Tests/Async/AsyncSemaphoreTests.swift
+++ b/Tests/Tests/Async/AsyncSemaphoreTests.swift
@@ -1,0 +1,46 @@
+//
+//  AsyncSemaphoreTests.swift
+//  PovioKit_Tests
+//
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import XCTest
+import PovioKitAsync
+
+final class AsyncSemaphoreTests: XCTestCase {
+  private actor ConcurrencyProbe {
+    private(set) var running: Int = 0
+    private(set) var maxRunning: Int = 0
+
+    func begin() {
+      running += 1
+      maxRunning = max(maxRunning, running)
+    }
+
+    func end() {
+      running -= 1
+    }
+  }
+
+  func testSemaphoreLimitsConcurrency() async throws {
+    let semaphore = AsyncSemaphore(value: 2)
+    let probe = ConcurrencyProbe()
+
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      for _ in 0 ..< 10 {
+        group.addTask {
+          try await semaphore.withPermit {
+            await probe.begin()
+            try await Task.sleep(for: .milliseconds(20))
+            await probe.end()
+          }
+        }
+      }
+      try await group.waitForAll()
+    }
+
+    let maxRunning = await probe.maxRunning
+    XCTAssertLessThanOrEqual(maxRunning, 2)
+  }
+}

--- a/Tests/Tests/Async/AsyncThrottleSequenceTests.swift
+++ b/Tests/Tests/Async/AsyncThrottleSequenceTests.swift
@@ -268,4 +268,3 @@ final class AsyncThrottleSequenceTests: XCTestCase {
     XCTAssertGreaterThanOrEqual(elapsed, .milliseconds(200), "Should respect large delay")
   }
 }
-

--- a/Tests/Tests/Async/AsyncTickerSequenceTests.swift
+++ b/Tests/Tests/Async/AsyncTickerSequenceTests.swift
@@ -1,0 +1,49 @@
+//
+//  AsyncTickerSequenceTests.swift
+//  PovioKit_Tests
+//
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import XCTest
+import PovioKitAsync
+
+final class AsyncTickerSequenceTests: XCTestCase {
+  func testTickerProducesTicksAtGivenInterval() async throws {
+    let ticker = AsyncTickerSequence(
+      clock: ContinuousClock(),
+      interval: .milliseconds(40)
+    )
+
+    var iterator = ticker.makeAsyncIterator()
+    guard let first = try await iterator.next() else {
+      XCTFail("Expected first tick")
+      return
+    }
+    guard let second = try await iterator.next() else {
+      XCTFail("Expected second tick")
+      return
+    }
+
+    let elapsed = second.duration(to: first) * -1
+    XCTAssertGreaterThanOrEqual(elapsed, .milliseconds(35))
+  }
+
+  func testTickerRespectsInitialDelay() async throws {
+    let start = ContinuousClock.now
+    let ticker = AsyncTickerSequence(
+      clock: ContinuousClock(),
+      interval: .milliseconds(10),
+      initialDelay: .milliseconds(80)
+    )
+
+    var iterator = ticker.makeAsyncIterator()
+    guard try await iterator.next() != nil else {
+      XCTFail("Expected first tick")
+      return
+    }
+    let elapsed = ContinuousClock.now - start
+
+    XCTAssertGreaterThanOrEqual(elapsed, .milliseconds(70))
+  }
+}

--- a/Tests/Tests/Async/AsyncUtilitiesTests.swift
+++ b/Tests/Tests/Async/AsyncUtilitiesTests.swift
@@ -1,0 +1,176 @@
+//
+//  AsyncUtilitiesTests.swift
+//  PovioKit_Tests
+//
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import XCTest
+import PovioKitAsync
+
+private enum RaceTestError: Error, Equatable {
+  case failed
+}
+
+@Sendable private func alwaysFailingOperation() async throws -> Int {
+  throw RaceTestError.failed
+}
+
+final class AsyncUtilitiesTests: XCTestCase {
+  private actor AttemptCounter {
+    private(set) var value: Int = 0
+
+    func increment() -> Int {
+      value += 1
+      return value
+    }
+  }
+
+  private enum TestError: Error, Equatable {
+    case failed
+    case nonRetryable
+  }
+
+  func testRetrySucceedsAfterTransientFailures() async throws {
+    let attempts = AttemptCounter()
+    let result = try await retry(
+      policy: .init(maxAttempts: 5, initialDelay: .milliseconds(1), backoffFactor: 2)
+    ) {
+      let current = await attempts.increment()
+      if current < 3 {
+        throw TestError.failed
+      }
+      return current
+    }
+
+    XCTAssertEqual(result, 3)
+    let count = await attempts.value
+    XCTAssertEqual(count, 3)
+  }
+
+  func testRetryThrowsAfterMaxAttempts() async {
+    let attempts = AttemptCounter()
+
+    do {
+      _ = try await retry(
+        policy: .init(maxAttempts: 3, initialDelay: .milliseconds(1))
+      ) {
+        _ = await attempts.increment()
+        throw TestError.failed
+      }
+      XCTFail("Expected retry to throw when all attempts fail")
+    } catch {
+      XCTAssertTrue(error is TestError)
+    }
+
+    let count = await attempts.value
+    XCTAssertEqual(count, 3)
+  }
+
+  func testRetryStopsWhenPredicateReturnsFalse() async {
+    let attempts = AttemptCounter()
+
+    do {
+      _ = try await retry(
+        policy: .init(maxAttempts: 5, initialDelay: .milliseconds(1)),
+        shouldRetry: { !($0 is TestError) }
+      ) {
+        _ = await attempts.increment()
+        throw TestError.nonRetryable
+      }
+      XCTFail("Expected non-retryable error to be rethrown")
+    } catch {
+      XCTAssertEqual(error as? TestError, .nonRetryable)
+    }
+
+    let count = await attempts.value
+    XCTAssertEqual(count, 1)
+  }
+
+  func testWithTimeoutReturnsValueWhenOperationCompletesInTime() async throws {
+    let value = try await withTimeout(.milliseconds(100)) {
+      try await Task.sleep(for: .milliseconds(10))
+      return 42
+    }
+
+    XCTAssertEqual(value, 42)
+  }
+
+  func testWithTimeoutThrowsWhenDeadlineExpires() async {
+    do {
+      _ = try await withTimeout(.milliseconds(20)) {
+        try await Task.sleep(for: .milliseconds(100))
+        return 1
+      }
+      XCTFail("Expected timeout error")
+    } catch {
+      XCTAssertEqual(error as? AsyncTimeoutError, .timedOut)
+    }
+  }
+
+  func testMakeAsyncStreamBuildsValuePipeline() async throws {
+    let pipe = makeAsyncStream() as AsyncStreamPipe<Int>
+
+    pipe.continuation.yield(1)
+    pipe.continuation.yield(2)
+    pipe.continuation.finish()
+
+    var values: [Int] = []
+    for await value in pipe.stream {
+      values.append(value)
+    }
+
+    XCTAssertEqual(values, [1, 2])
+  }
+
+  func testMakeAsyncThrowingStreamPropagatesFailure() async {
+    enum LocalError: Error, Equatable {
+      case boom
+    }
+
+    let pipe = makeAsyncThrowingStream() as AsyncThrowingStreamPipe<Int>
+    pipe.continuation.yield(1)
+    pipe.continuation.finish(throwing: LocalError.boom)
+
+    var iterator = pipe.stream.makeAsyncIterator()
+
+    do {
+      let first = try await iterator.next()
+      XCTAssertEqual(first, 1)
+      _ = try await iterator.next()
+      XCTFail("Expected stream failure")
+    } catch {
+      XCTAssertEqual(error as? LocalError, .boom)
+    }
+  }
+
+  func testRaceReturnsFastestResult() async throws {
+    let value = try await race(
+      {
+        try await Task.sleep(for: .milliseconds(80))
+        return 1
+      },
+      {
+        try await Task.sleep(for: .milliseconds(10))
+        return 2
+      }
+    )
+
+    XCTAssertEqual(value, 2)
+  }
+
+  func testRaceThrowsWhenFastestOperationFails() async {
+    do {
+      _ = try await race(
+        alwaysFailingOperation,
+        {
+          try await Task.sleep(for: .milliseconds(40))
+          return 42
+        }
+      )
+      XCTFail("Expected race to throw first error")
+    } catch {
+      XCTAssertEqual(error as? RaceTestError, .failed)
+    }
+  }
+}

--- a/Tests/Tests/Async/AsyncUtilitiesTests.swift
+++ b/Tests/Tests/Async/AsyncUtilitiesTests.swift
@@ -98,8 +98,8 @@ final class AsyncUtilitiesTests: XCTestCase {
 
   func testWithTimeoutThrowsWhenDeadlineExpires() async {
     do {
-      _ = try await withTimeout(.milliseconds(20)) {
-        try await Task.sleep(for: .milliseconds(100))
+      _ = try await withTimeout(.milliseconds(1)) {
+        try await Task.sleep(for: .seconds(5))
         return 1
       }
       XCTFail("Expected timeout error")

--- a/Tests/Tests/Async/TaskCoalescerTests.swift
+++ b/Tests/Tests/Async/TaskCoalescerTests.swift
@@ -1,0 +1,47 @@
+//
+//  TaskCoalescerTests.swift
+//  PovioKit_Tests
+//
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import XCTest
+import PovioKitAsync
+
+final class TaskCoalescerTests: XCTestCase {
+  private actor Counter {
+    private(set) var count: Int = 0
+
+    func increment() -> Int {
+      count += 1
+      return count
+    }
+  }
+
+  func testCoalescerRunsOperationOnlyOncePerKey() async throws {
+    let coalescer = TaskCoalescer<String, Int>()
+    let counter = Counter()
+
+    let results = try await withThrowingTaskGroup(of: Int.self) { group in
+      for _ in 0 ..< 8 {
+        group.addTask {
+          try await coalescer.value(for: "shared-key") {
+            _ = await counter.increment()
+            try await Task.sleep(for: .milliseconds(30))
+            return 7
+          }
+        }
+      }
+
+      var values: [Int] = []
+      for try await value in group {
+        values.append(value)
+      }
+      return values
+    }
+
+    XCTAssertEqual(results, Array(repeating: 7, count: 8))
+    let invocationCount = await counter.count
+    XCTAssertEqual(invocationCount, 1)
+  }
+}

--- a/Tests/Tests/UI/AppKit/Extensions/AppKitExtensionsTests.swift
+++ b/Tests/Tests/UI/AppKit/Extensions/AppKitExtensionsTests.swift
@@ -1,0 +1,32 @@
+#if os(macOS)
+import XCTest
+import AppKit
+@testable import PovioKitAppKit
+
+final class AppKitExtensionsTests: XCTestCase {
+  func testWindowBoundsUsesFrameSizeWithZeroOrigin() {
+    let contentRect = NSRect(x: 24, y: 32, width: 320, height: 180)
+    let window = NSWindow(
+      contentRect: contentRect,
+      styleMask: [.titled],
+      backing: .buffered,
+      defer: false
+    )
+
+    XCTAssertEqual(window.bounds.origin.x, 0)
+    XCTAssertEqual(window.bounds.origin.y, 0)
+    XCTAssertEqual(window.bounds.size.width, window.frame.width)
+    XCTAssertEqual(window.bounds.size.height, window.frame.height)
+  }
+
+  func testRenderAsImageReturnsImageMatchingViewSize() {
+    let view = NSView(frame: NSRect(x: 0, y: 0, width: 120, height: 80))
+
+    let image = view.renderAsImage()
+
+    XCTAssertNotNil(image)
+    XCTAssertEqual(image?.size.width, 120)
+    XCTAssertEqual(image?.size.height, 80)
+  }
+}
+#endif

--- a/Tests/Tests/UI/SwiftUI/RemoteImageProcessorsTests.swift
+++ b/Tests/Tests/UI/SwiftUI/RemoteImageProcessorsTests.swift
@@ -1,0 +1,103 @@
+//
+//  RemoteImageProcessorsTests.swift
+//  PovioKit_Tests
+//
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import XCTest
+import Kingfisher
+import PovioKitSwiftUI
+
+final class RemoteImageProcessorsTests: XCTestCase {
+  func testJPEGProcessorClampsQualityAndIdentifier() {
+    let processor = JPEGImageProcessor(compressionQuality: 3.5)
+
+    XCTAssertEqual(processor.compressionQuality, 1.0)
+    XCTAssertEqual(processor.identifier, "com.povio.JPEGImageProcessor(1.0)")
+  }
+
+  func testHEICProcessorClampsQualityAndIdentifier() {
+    let processor = HEICImageProcessor(compressionQuality: -1.0)
+
+    XCTAssertEqual(processor.compressionQuality, 0.0)
+    XCTAssertEqual(processor.identifier, "com.povio.HEICImageProcessor(0.0)")
+  }
+
+  func testJPEGProcessorDecodesImageData() throws {
+    let data = try makePNGData()
+    let processor = JPEGImageProcessor(compressionQuality: 0.8)
+
+    let output = processor.process(item: .data(data), options: makeOptions())
+
+    XCTAssertNotNil(output)
+  }
+
+  func testHEICProcessorDecodesImageData() throws {
+    let data = try makePNGData()
+    let processor = HEICImageProcessor(compressionQuality: 0.8)
+
+    let output = processor.process(item: .data(data), options: makeOptions())
+
+    XCTAssertNotNil(output)
+  }
+
+  func testJPEGProcessorProcessesImageInput() throws {
+    let image = try makeImage()
+    let processor = JPEGImageProcessor(compressionQuality: 0.7)
+
+    let output = processor.process(item: .image(image), options: makeOptions())
+
+    XCTAssertNotNil(output)
+  }
+
+  func testHEICProcessorProcessesImageInput() throws {
+    let image = try makeImage()
+    let processor = HEICImageProcessor(compressionQuality: 0.7)
+
+    let output = processor.process(item: .image(image), options: makeOptions())
+
+    XCTAssertNotNil(output)
+  }
+}
+
+private func makeOptions() -> KingfisherParsedOptionsInfo {
+  KingfisherParsedOptionsInfo(KingfisherOptionsInfo([]))
+}
+
+#if canImport(UIKit)
+import UIKit
+
+private func makeImage() throws -> UIImage {
+  let renderer = UIGraphicsImageRenderer(size: CGSize(width: 32, height: 32))
+  let image = renderer.image { context in
+    UIColor.systemBlue.setFill()
+    context.fill(CGRect(x: 0, y: 0, width: 32, height: 32))
+  }
+  return image
+}
+
+private func makePNGData() throws -> Data {
+  let image = try makeImage()
+  return try XCTUnwrap(image.pngData())
+}
+#elseif canImport(AppKit)
+import AppKit
+
+private func makeImage() throws -> NSImage {
+  let size = NSSize(width: 32, height: 32)
+  let image = NSImage(size: size)
+  image.lockFocus()
+  NSColor.systemBlue.setFill()
+  NSBezierPath(rect: NSRect(origin: .zero, size: size)).fill()
+  image.unlockFocus()
+  return image
+}
+
+private func makePNGData() throws -> Data {
+  let image = try makeImage()
+  let tiffData = try XCTUnwrap(image.tiffRepresentation)
+  let bitmapImage = try XCTUnwrap(NSBitmapImageRep(data: tiffData))
+  return try XCTUnwrap(bitmapImage.representation(using: .png, properties: [:]))
+}
+#endif


### PR DESCRIPTION
## Summary

This PR significantly improves `PovioKit` across testing, documentation, and async capabilities.

- Strengthens platform confidence by adding macOS-focused test coverage and CI execution.
- Improves package hygiene and discoverability (README/platform matrix, migration/docs links, package collection consistency, scheme cleanup).
- Adds DocC foundations and automated docs publishing workflow.
- Expands `PovioKitAsync` into a more complete concurrency toolkit with production-ready utilities and examples.

## What Changed

### Platform and Quality Improvements
- Added `PovioKitAppKit` to test target dependencies in `Package.swift`.
- Added AppKit extension tests:
  - `Tests/Tests/UI/AppKit/Extensions/AppKitExtensionsTests.swift`
- Updated CI workflow:
  - iOS test job retained.
  - Added dedicated macOS test job in `.github/workflows/Tests.yml`.
- Cleaned stale package scheme entries in:
  - `.swiftpm/xcode/xcshareddata/xcschemes/PovioKit-Package.xcscheme`

### Documentation and Repo Consistency
- Updated root docs and links:
  - `README.md` (platform support matrix, docs section, consistency fixes, async recipes link)
  - `MIGRATING.md` (fixed stale links/typos and added latest async migration notes)
  - `Collections/poviokit.json` (readme URL consistency)
- Added/expanded module DocC landing pages across products.
- Added docs pipeline:
  - `.github/workflows/Docs.yml` for DocC build + Pages deployment.
- Added async recipe guide:
  - `Resources/Async/Recipes.md`
  - linked from `Resources/Async/README.md` and root `README.md`.

### Async Product Expansion (`PovioKitAsync`)
Added new APIs and supporting docs/tests:

- `AsyncDebounceSequence` + `AsyncSequence.debounce(...)`
- `AsyncSemaphore` for bounded concurrency
- `TaskCoalescer<Key, Value>` for in-flight deduplication
- `AsyncTickerSequence` for periodic ticks
- `retry` enhancements:
  - `shouldRetry` predicate
  - jitter support in `AsyncRetryPolicy`
- `race` helpers for first-completed result
- Existing async docs/examples expanded in source comments and README.

## Test Coverage Added/Updated

- New async test suites:
  - `AsyncDebounceSequenceTests`
  - `AsyncSemaphoreTests`
  - `TaskCoalescerTests`
  - `AsyncTickerSequenceTests`
- Extended:
  - `AsyncUtilitiesTests` (retry predicate + race coverage)
- Relocated async tests into dedicated async test area:
  - `Tests/Tests/Async/...`

## Migration Notes

- Added new migration section for async expansion in `MIGRATING.md` (`< 6.3.0`) covering:
  - debounce, race, semaphore, coalescer, ticker
  - retry enhancements and compatibility behavior

## Notes

- Existing upstream/dependency warning from Kingfisher (`Info.plist` unhandled file) may still appear during local builds and is unrelated to these changes.