### PR TITLE
Core/Updates

### DIFF
--- a/Resources/Core/README.md
+++ b/Resources/Core/README.md
@@ -1,6 +1,6 @@
 # PovioKit: Core
 
-Core package includes essentials needed for the development and for other packages.
+Core includes essentials used in app development and by other PovioKit packages.
 
 The module is intentionally foundation-first and serves as the base dependency for other PovioKit products.
 

--- a/Resources/Core/README.md
+++ b/Resources/Core/README.md
@@ -2,6 +2,8 @@
 
 Core package includes essentials needed for the development and for other packages.
 
+The module is intentionally foundation-first and serves as the base dependency for other PovioKit products.
+
 ### Essentials
 | Components |
 | :--- |
@@ -26,3 +28,7 @@ Core package includes essentials needed for the development and for other packag
 | [Result](/Sources/Core/Extensions/Foundation/Result+PovioKit.swift) | | |
 | [String](/Sources/Core/Extensions/Foundation/String+PovioKit.swift) | | |
 | [URL](/Sources/Core/Extensions/Foundation/URL+PovioKit.swift) | | |
+
+### Notes
+- Some app lifecycle helpers are only available when UIKit can be imported.
+- Notification helpers support `post`, `observe`, and Combine `publisher` workflows.

--- a/Sources/Core/AppInfo.swift
+++ b/Sources/Core/AppInfo.swift
@@ -33,7 +33,7 @@ public enum AppInfo {
   }
 #endif
   
-  /// Opens `App Store` deep linking to the app with provided id.
+  /// Opens App Store deep link for the provided app ID.
   ///
   /// - Returns: `true` when the URL is forwarded to the system opener.
   @discardableResult
@@ -42,7 +42,7 @@ public enum AppInfo {
     return openUrl(appStoreUrl)
   }
   
-  /// Passing the `number` will trigger the system call with "tel://" prefix.
+  /// Initiates a phone call using a `tel://` URL.
   ///
   /// Characters not supported by `tel://` URLs are removed before opening.
   ///
@@ -57,9 +57,9 @@ public enum AppInfo {
     return openUrl(callUrl)
   }
   
-  /// Opens given `url` in the default browser, if `canOpenURL` method returns true.
+  /// Opens the given URL in the default browser when available.
   ///
-  /// If `isSafari` param is true, url will be opened in the Safari instead, overriding the default selected browser.
+  /// If `inSafari` is `true`, Safari is preferred when platform support is available.
   ///
   /// - Returns: `true` when the URL passes `canOpenURL` and is forwarded for opening.
   @discardableResult
@@ -97,22 +97,22 @@ public enum AppInfo {
 #endif
   }
   
-  /// Returns bundle id
+  /// Returns the bundle identifier.
   public static var bundleId: String {
     Bundle.main.object(forInfoDictionaryKey: "CFBundleIdentifier") as? String ?? "/"
   }
   
-  /// Returns app name
+  /// Returns the app name.
   public static var name: String {
     Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "/"
   }
   
-  /// Returns App Store build, e.g. `84`
+  /// Returns the app build number, for example `84`.
   public static var build: String {
     Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "/"
   }
   
-  /// Returns App Store app version, e.g. `1.9.3`
+  /// Returns the app version, for example `1.9.3`.
   public static var version: String {
     Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "/"
   }

--- a/Sources/Core/AppInfo.swift
+++ b/Sources/Core/AppInfo.swift
@@ -15,35 +15,60 @@ import AppKit
 public enum AppInfo {
 #if os(iOS)
   /// Opens `Settings` app for current app.
-  public static func openSettings() {
-    URL(string: UIApplication.openSettingsURLString).map { openUrl($0) }
+  ///
+  /// - Returns: `true` when the URL is forwarded to the system opener.
+  @discardableResult
+  public static func openSettings() -> Bool {
+    guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else { return false }
+    return openUrl(settingsUrl)
   }
   
   /// Opens `Notifications` section in `Settings` app.
-  public static func openNotificationSettings() {
-    URL(string: UIApplication.openNotificationSettingsURLString).map { openUrl($0) }
+  ///
+  /// - Returns: `true` when the URL is forwarded to the system opener.
+  @discardableResult
+  public static func openNotificationSettings() -> Bool {
+    guard let settingsUrl = URL(string: UIApplication.openNotificationSettingsURLString) else { return false }
+    return openUrl(settingsUrl)
   }
 #endif
   
   /// Opens `App Store` deep linking to the app with provided id.
-  public static func openAppStore(appId: String) {
-    guard let url = URL(string: "itms-apps://apps.apple.com/app/id\(appId)") else { return }
-    openUrl(url)
+  ///
+  /// - Returns: `true` when the URL is forwarded to the system opener.
+  @discardableResult
+  public static func openAppStore(appId: String) -> Bool {
+    guard let appStoreUrl = URL(string: "itms-apps://apps.apple.com/app/id\(appId)") else { return false }
+    return openUrl(appStoreUrl)
   }
   
   /// Passing the `number` will trigger the system call with "tel://" prefix.
-  public static func call(_ number: String) {
-    URL(string: "tel://" + number).map { openUrl($0) }
+  ///
+  /// Characters not supported by `tel://` URLs are removed before opening.
+  ///
+  /// - Returns: `true` when the sanitized number can be opened.
+  @discardableResult
+  public static func call(_ number: String) -> Bool {
+    let normalizedNumber = number
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .filter { $0.isWholeNumber || $0 == "+" || $0 == "*" || $0 == "#" || $0 == "," }
+    guard !normalizedNumber.isEmpty else { return false }
+    guard let callUrl = URL(string: "tel://\(normalizedNumber)") else { return false }
+    return openUrl(callUrl)
   }
   
   /// Opens given `url` in the default browser, if `canOpenURL` method returns true.
   ///
   /// If `isSafari` param is true, url will be opened in the Safari instead, overriding the default selected browser.
-  public static func openUrl(_ url: URL, inSafari: Bool = false) {
+  ///
+  /// - Returns: `true` when the URL passes `canOpenURL` and is forwarded for opening.
+  @discardableResult
+  public static func openUrl(_ url: URL, inSafari: Bool = false) -> Bool {
     var targetUrl = url
 #if os(iOS)
     if inSafari, #available(iOS 17.5, *) {
-      targetUrl = URL(string: "x-safari-\(url.absoluteString)")!
+      guard let safariUrl = URL(string: "x-safari-\(url.absoluteString)") else { return false }
+      targetUrl = safariUrl
     }
     let canOpen = AppInfoURLHandlerStore.canOpenUrlHandlerForTesting ?? { target in
       UIApplication.shared.canOpenURL(target)
@@ -51,8 +76,9 @@ public enum AppInfo {
     let open = AppInfoURLHandlerStore.openUrlHandlerForTesting ?? { target in
       UIApplication.shared.open(target, options: [:])
     }
-    guard canOpen(targetUrl) else { return }
+    guard canOpen(targetUrl) else { return false }
     open(targetUrl)
+    return true
 #elseif os(macOS)
     if inSafari, let safariUrl = URL(string: "safari://\(url.absoluteString)") {
       targetUrl = safariUrl
@@ -63,8 +89,11 @@ public enum AppInfo {
     let open = AppInfoURLHandlerStore.openUrlHandlerForTesting ?? { target in
       NSWorkspace.shared.open(target)
     }
-    guard canOpen(targetUrl) else { return }
+    guard canOpen(targetUrl) else { return false }
     open(targetUrl)
+    return true
+#else
+    return false
 #endif
   }
   

--- a/Sources/Core/Extensions/Foundation/Collection+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/Collection+PovioKit.swift
@@ -10,7 +10,6 @@ import Foundation
 
 public extension Collection {
   /// Returns the element at the specified `index` if it is within bounds, otherwise `nil`.
-  /// Returns the element at the specified `index` if it is within bounds, otherwise `nil`.
   ///
   /// This subscript safely accesses an element in the collection at the given index. If the index is out of bounds, it returns `nil` instead of causing a runtime error.
   ///
@@ -119,8 +118,7 @@ public extension Collection {
       grouping: self,
       by: {
         let components = calendar.dateComponents(dateComponents, from: extractDate($0))
-        let date = calendar.date(from: components) ?? Date()
-        return date
+        return calendar.date(from: components) ?? extractDate($0)
       }
     )
   }

--- a/Sources/Core/Extensions/Foundation/DateFormatter+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/DateFormatter+PovioKit.swift
@@ -12,80 +12,68 @@ public extension DateFormatter {
   /// Format a time in a 12-hour format with AM/PM designation.
   ///
   /// `9:41 PM`
-  static let time12Hour: DateFormatter = {
-    let dateFormatter = DateFormatter()
-    dateFormatter.locale = .autoupdatingCurrent
-    dateFormatter.dateFormat = "h:mm a"
-    return dateFormatter
-  }()
+  ///
+  /// - Important: Returns a fresh formatter instance on each access to avoid
+  /// shared mutable state across threads.
+  static var time12Hour: DateFormatter {
+    makeFormatter(with: "h:mm a")
+  }
   
   /// Format a time in a 24-hour format without AM/PM designation.
   ///
   /// `9:41`
-  static let time24Hour: DateFormatter = {
-    let dateFormatter = DateFormatter()
-    dateFormatter.locale = .autoupdatingCurrent
-    dateFormatter.dateFormat = "H:mm"
-    return dateFormatter
-  }()
+  static var time24Hour: DateFormatter {
+    makeFormatter(with: "H:mm")
+  }
   
   /// Format a date in a long format.
   ///
   /// `October 2, 2024`
-  static let longDate: DateFormatter = {
-    let dateFormatter = DateFormatter()
-    dateFormatter.locale = .autoupdatingCurrent
-    dateFormatter.dateFormat = "MMMM d, yyyy"
-    return dateFormatter
-  }()
+  static var longDate: DateFormatter {
+    makeFormatter(with: "MMMM d, yyyy")
+  }
   
   /// Format a date in a abbreviated format.
   ///
   /// `Oct 2, 2024`
-  static let abbreviatedDate: DateFormatter = {
-    let dateFormatter = DateFormatter()
-    dateFormatter.locale = .autoupdatingCurrent
-    dateFormatter.dateFormat = "MMM d, yyyy"
-    return dateFormatter
-  }()
+  static var abbreviatedDate: DateFormatter {
+    makeFormatter(with: "MMM d, yyyy")
+  }
   
   /// Format a date using an ISO format.
   ///
   /// `2024-10-02`
-  static let iso8601Date: DateFormatter = {
-    let dateFormatter = DateFormatter()
-    dateFormatter.locale = .autoupdatingCurrent
-    dateFormatter.dateFormat = "yyyy-MM-dd"
-    return dateFormatter
-  }()
+  static var iso8601Date: DateFormatter {
+    makeFormatter(with: "yyyy-MM-dd")
+  }
   
   /// Format a date using an US format.
   ///
   /// `10/02/2024`
-  static let usDate: DateFormatter = {
-    let dateFormatter = DateFormatter()
-    dateFormatter.locale = .autoupdatingCurrent
-    dateFormatter.dateFormat = "MM/dd/yyyy"
-    return dateFormatter
-  }()
+  static var usDate: DateFormatter {
+    makeFormatter(with: "MM/dd/yyyy")
+  }
   
   /// Format a date using an EU format.
   ///
   /// `02/10/2024`
-  static let euDate: DateFormatter = {
-    let dateFormatter = DateFormatter()
-    dateFormatter.locale = .autoupdatingCurrent
-    dateFormatter.dateFormat = "dd/MM/yyyy"
-    return dateFormatter
-  }()
+  static var euDate: DateFormatter {
+    makeFormatter(with: "dd/MM/yyyy")
+  }
   
   /// Format a date using an RFC 1123 format.
   ///
   /// `Tue, 02 Oct 2024 15:30:00 GMT`
-  static let rfc1123Date: DateFormatter = {
+  static var rfc1123Date: DateFormatter {
+    makeFormatter(with: "EEE, dd MMM yyyy HH:mm:ss zzz")
+  }
+}
+
+private extension DateFormatter {
+  static func makeFormatter(with format: String) -> DateFormatter {
     let dateFormatter = DateFormatter()
     dateFormatter.locale = .autoupdatingCurrent
-    dateFormatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+    dateFormatter.dateFormat = format
     return dateFormatter
-  }()
+  }
 }

--- a/Sources/Core/Extensions/Foundation/DateFormatter+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/DateFormatter+PovioKit.swift
@@ -33,7 +33,7 @@ public extension DateFormatter {
     makeFormatter(with: "MMMM d, yyyy")
   }
   
-  /// Format a date in a abbreviated format.
+  /// Formats a date using an abbreviated format.
   ///
   /// `Oct 2, 2024`
   static var abbreviatedDate: DateFormatter {
@@ -47,7 +47,7 @@ public extension DateFormatter {
     makeFormatter(with: "yyyy-MM-dd")
   }
   
-  /// Format a date using an US format.
+  /// Formats a date using a US format.
   ///
   /// `10/02/2024`
   static var usDate: DateFormatter {

--- a/Sources/Core/Extensions/Foundation/DecodableDictionary+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/DecodableDictionary+PovioKit.swift
@@ -22,10 +22,11 @@ import Foundation
 /// ```
 public struct DecodableDictionary: Decodable {
   public typealias Value = [String: Any]
-  public let dictionary: Value?
+  public let dictionary: Value
   
   public init(from decoder: Decoder) throws {
-    dictionary = try? decoder.container(keyedBy: AnyCodingKey.self).decode(Value.self)
+    let container = try decoder.container(keyedBy: AnyCodingKey.self)
+    dictionary = try container.decode(Value.self)
   }
 }
 

--- a/Sources/Core/Extensions/Foundation/Encodable+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/Encodable+PovioKit.swift
@@ -8,6 +8,17 @@
 
 import Foundation
 
+public enum EncodableJSONError: Error, LocalizedError, Equatable {
+  case invalidTopLevelObject
+  
+  public var errorDescription: String? {
+    switch self {
+    case .invalidTopLevelObject:
+      return "Encoded payload is not a JSON object dictionary."
+    }
+  }
+}
+
 public extension Encodable {
   /// Encodes given encodable object into json/dictionary.
   ///
@@ -25,6 +36,9 @@ public extension Encodable {
   func toJSON(with encoder: JSONEncoder) throws -> [String: Any] {
     let data = try encoder.encode(self)
     let json = try JSONSerialization.jsonObject(with: data, options: [])
-    return (json as? [String: Any]) ?? [:]
+    guard let dictionary = json as? [String: Any] else {
+      throw EncodableJSONError.invalidTopLevelObject
+    }
+    return dictionary
   }
 }

--- a/Sources/Core/Extensions/Foundation/Result+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/Result+PovioKit.swift
@@ -1,6 +1,6 @@
 //
 //  Result+PovioKit.swift
-//  Alamofire
+//  PovioKit
 //
 //  Created by Borut Tomazin on 24/02/2020.
 //  Copyright © 2026 Povio Inc. All rights reserved.

--- a/Sources/Core/Extensions/Foundation/String+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/String+PovioKit.swift
@@ -17,7 +17,13 @@ public extension String {
   }
   
   /// Trim white spaces from both ends
+  @available(*, deprecated, renamed: "trimmed")
   var trimed: String {
+    trimmed
+  }
+  
+  /// Trim white spaces from both ends.
+  var trimmed: String {
     trimmingCharacters(in: .whitespacesAndNewlines)
   }
   

--- a/Sources/Core/Extensions/Foundation/String+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/String+PovioKit.swift
@@ -16,13 +16,13 @@ public extension String {
     return withVaList(args) { NSString(format: localizedString, locale: Locale.current, arguments: $0) as String }
   }
   
-  /// Trim white spaces from both ends
+  /// Trims whitespace and newlines from both ends.
   @available(*, deprecated, renamed: "trimmed")
   var trimed: String {
     trimmed
   }
   
-  /// Trim white spaces from both ends.
+  /// Trims whitespace and newlines from both ends.
   var trimmed: String {
     trimmingCharacters(in: .whitespacesAndNewlines)
   }

--- a/Sources/Core/Extensions/Foundation/URL+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/URL+PovioKit.swift
@@ -66,15 +66,14 @@ public extension URL {
 extension URL: @retroactive ExpressibleByExtendedGraphemeClusterLiteral {}
 extension URL: @retroactive ExpressibleByUnicodeScalarLiteral {}
 extension Foundation.URL: Swift.ExpressibleByStringLiteral {
-  /// A failable initializer that allows a `URL` object to be created from a string literal.
+  /// Creates a `URL` object from a string literal.
   ///
-  /// This initializer enables a `URL` to be initialized directly from a string literal, which is
-  /// especially useful when working with URL objects in a concise way. If the string is not a valid
-  /// URL, it will trigger a runtime failure with a fatal error.
+  /// This initializer enables `URL` values to be initialized directly from string literals.
+  /// If the literal is invalid, PovioKit emits an assertion failure in debug builds and falls
+  /// back to `about:blank` instead of crashing in production.
   ///
   /// - Parameter value: A string literal representing a URL.
-  /// - Precondition: The string literal must represent a valid URL. Otherwise, the program will
-  ///   terminate with a fatal error.
+  /// - Warning: Invalid literals indicate a programmer error and should be fixed at the call site.
   ///
   /// ## Example
   /// ```swift
@@ -82,9 +81,13 @@ extension Foundation.URL: Swift.ExpressibleByStringLiteral {
   /// print(myURL) // Prints: https://www.povio.com
   /// ```
   public init(stringLiteral value: String) {
-    guard let url = URL(string: value) else {
-      fatalError("Invalid URL string!")
+    if let url = URL(string: value) {
+      self = url
+      return
     }
-    self = url
+    #if DEBUG
+    assertionFailure("Invalid URL string literal: \(value)")
+    #endif
+    self = URL(string: "about:blank")!
   }
 }

--- a/Sources/Core/Extensions/Foundation/URL+PovioKit.swift
+++ b/Sources/Core/Extensions/Foundation/URL+PovioKit.swift
@@ -22,14 +22,14 @@ public extension URL {
     self.init(string: string)
   }
   
-  /// Append parameter to the URL.
+  /// Appends a query parameter to the URL.
   ///
   /// ## Example
   /// ```
   /// let someURL: URL = "https://povio.com"
   /// let newURL = someURL
   ///   .appending("accept", value: "developers")
-  ///   .appending("tech", value: "iOS"
+  ///   .appending("tech", value: "iOS")
   ///
   /// print(newURL) // https://povio.com?accept=developers&tech=iOS
   /// ```
@@ -69,8 +69,8 @@ extension Foundation.URL: Swift.ExpressibleByStringLiteral {
   /// Creates a `URL` object from a string literal.
   ///
   /// This initializer enables `URL` values to be initialized directly from string literals.
-  /// If the literal is invalid, PovioKit emits an assertion failure in debug builds and falls
-  /// back to `about:blank` instead of crashing in production.
+  /// In debug builds, invalid literals trigger `assertionFailure` to surface programmer errors.
+  /// In other builds, invalid literals fall back to `about:blank`.
   ///
   /// - Parameter value: A string literal representing a URL.
   /// - Warning: Invalid literals indicate a programmer error and should be fixed at the call site.

--- a/Sources/Core/Logger/Logger.swift
+++ b/Sources/Core/Logger/Logger.swift
@@ -6,13 +6,14 @@
 //  Copyright © 2026 Povio Inc. All rights reserved.
 //
 
+import Foundation
 import OSLog
 
 public final class Logger {
   public typealias Parameters = [String: Any]
   public static let shared = Logger()
   public var logLevel: LogLevel = .none
-  
+
   private init() {}
 }
 
@@ -85,7 +86,7 @@ private extension Logger {
       messagePrint += "\(nl)\(groupedParams)"
     }
     
-    let category = "\(fileName) - \(function) - line \(line)"
+    let category = "\(fileName).\(function)"
     let logger = os.Logger(subsystem: Bundle.main.bundleIdentifier ?? "povioKit.logger", category: category)
     switch level {
     case .none:

--- a/Sources/Core/PovioKitCore.docc/PovioKitCore.md
+++ b/Sources/Core/PovioKitCore.docc/PovioKitCore.md
@@ -7,3 +7,20 @@ Core primitives, extensions, and shared building blocks used across PovioKit mod
 `PovioKitCore` contains reusable foundation utilities and low-level helpers intended to stay lightweight and broadly applicable.
 
 This module is intended as the shared base layer for other PovioKit products.
+
+## Main building blocks
+
+- `AppInfo` for app metadata and safe deep-link opening helpers.
+- `Logger` for lightweight app-level logging on top of `OSLog`.
+- `AppNotification` and `NotificationCenter` convenience APIs for posting, observing, and publishing notifications.
+- Foundation extensions for `Collection`, `Date`, `String`, `URL`, and related utility types.
+
+## Platform notes
+
+- Foundation extensions are available on all PovioKitCore-supported platforms.
+- Some APIs (for example app lifecycle notifications and StoreKit helpers) require UIKit and are only available where UIKit is present.
+
+## Testing
+
+- Core coverage lives in `Tests/Tests/Core`.
+- The test suite includes URL safety, logger behavior, date formatting, and notification helper coverage.

--- a/Tests/Tests/Core/AppInfoTests.swift
+++ b/Tests/Tests/Core/AppInfoTests.swift
@@ -12,9 +12,10 @@ import XCTest
 final class AppInfoTests: XCTestCase {
   private final class URLOpenSpy {
     private(set) var openedUrls: [URL] = []
+    var shouldAllowOpening = true
     
     func canOpen(_ url: URL) -> Bool {
-      true
+      shouldAllowOpening
     }
     
     func open(_ url: URL) {
@@ -131,10 +132,8 @@ final class AppInfoTests: XCTestCase {
   func testOpenAppStoreWithValidId() {
     let spy = URLOpenSpy()
     installSpy(spy)
-    XCTAssertNoThrow(
-      AppInfo.openAppStore(appId: "123456789"),
-      "Should not crash with valid app ID"
-    )
+    let result = AppInfo.openAppStore(appId: "123456789")
+    XCTAssertTrue(result, "Should report success with valid app ID")
     XCTAssertEqual(spy.openedUrls.count, 1, "Should attempt to open one App Store URL")
     XCTAssertEqual(spy.openedUrls.first?.absoluteString, "itms-apps://apps.apple.com/app/id123456789")
   }
@@ -142,10 +141,8 @@ final class AppInfoTests: XCTestCase {
   func testOpenAppStoreWithEmptyId() {
     let spy = URLOpenSpy()
     installSpy(spy)
-    XCTAssertNoThrow(
-      AppInfo.openAppStore(appId: ""),
-      "Should not crash with empty app ID"
-    )
+    let result = AppInfo.openAppStore(appId: "")
+    XCTAssertTrue(result, "Should still return success when URL can be formed")
     XCTAssertEqual(spy.openedUrls.count, 1, "Should still build and open URL for empty app ID")
   }
   
@@ -153,10 +150,8 @@ final class AppInfoTests: XCTestCase {
     let longId = String(repeating: "1", count: 20)
     let spy = URLOpenSpy()
     installSpy(spy)
-    XCTAssertNoThrow(
-      AppInfo.openAppStore(appId: longId),
-      "Should handle long app IDs"
-    )
+    let result = AppInfo.openAppStore(appId: longId)
+    XCTAssertTrue(result, "Should handle long app IDs")
     XCTAssertEqual(spy.openedUrls.count, 1, "Should attempt to open URL for long app ID")
   }
   
@@ -167,10 +162,8 @@ final class AppInfoTests: XCTestCase {
     installSpy(spy)
     
     for appId in specialIds {
-      XCTAssertNoThrow(
-        AppInfo.openAppStore(appId: appId),
-        "Should handle special characters in app ID"
-      )
+      let result = AppInfo.openAppStore(appId: appId)
+      XCTAssertTrue(result, "Should handle special characters in app ID")
     }
     XCTAssertEqual(spy.openedUrls.count, specialIds.count, "Should attempt to open URL for each app ID")
   }
@@ -180,10 +173,8 @@ final class AppInfoTests: XCTestCase {
   func testCallWithValidNumber() {
     let spy = URLOpenSpy()
     installSpy(spy)
-    XCTAssertNoThrow(
-      AppInfo.call("1234567890"),
-      "Should not crash with valid number"
-    )
+    let result = AppInfo.call("1234567890")
+    XCTAssertTrue(result, "Should report success with valid number")
     XCTAssertEqual(spy.openedUrls.count, 1, "Should attempt one phone call URL")
     XCTAssertEqual(spy.openedUrls.first?.absoluteString, "tel://1234567890")
   }
@@ -191,11 +182,9 @@ final class AppInfoTests: XCTestCase {
   func testCallWithEmptyNumber() {
     let spy = URLOpenSpy()
     installSpy(spy)
-    XCTAssertNoThrow(
-      AppInfo.call(""),
-      "Should not crash with empty number"
-    )
-    XCTAssertEqual(spy.openedUrls.count, 1, "Should still build and open tel URL")
+    let result = AppInfo.call("")
+    XCTAssertFalse(result, "Should fail for empty numbers")
+    XCTAssertEqual(spy.openedUrls.count, 0, "Should not attempt to open an invalid tel URL")
   }
   
   func testCallWithInternationalFormat() {
@@ -204,10 +193,8 @@ final class AppInfoTests: XCTestCase {
     installSpy(spy)
     
     for number in numbers {
-      XCTAssertNoThrow(
-        AppInfo.call(number),
-        "Should handle international number formats"
-      )
+      let result = AppInfo.call(number)
+      XCTAssertTrue(result, "Should handle international number formats")
     }
     XCTAssertEqual(spy.openedUrls.count, numbers.count, "Should attempt one URL per phone number")
   }
@@ -218,12 +205,15 @@ final class AppInfoTests: XCTestCase {
     installSpy(spy)
     
     for number in numbers {
-      XCTAssertNoThrow(
-        AppInfo.call(number),
-        "Should handle numbers with special characters"
-      )
+      let result = AppInfo.call(number)
+      XCTAssertTrue(result, "Should handle numbers with special characters")
     }
     XCTAssertEqual(spy.openedUrls.count, numbers.count, "Should attempt one URL per phone number")
+    XCTAssertEqual(
+      spy.openedUrls.map(\.absoluteString),
+      ["tel://1234567890", "tel://1234567890", "tel://1234567890"],
+      "Should sanitize phone numbers to URL-safe values"
+    )
   }
   
   // MARK: - URL Opening
@@ -236,10 +226,8 @@ final class AppInfoTests: XCTestCase {
     
     let spy = URLOpenSpy()
     installSpy(spy)
-    XCTAssertNoThrow(
-      AppInfo.openUrl(url),
-      "Should not crash with valid URL"
-    )
+    let result = AppInfo.openUrl(url)
+    XCTAssertTrue(result, "Should report success with valid URL")
     XCTAssertEqual(spy.openedUrls.first, url, "Should forward exact URL to opener")
   }
   
@@ -251,10 +239,8 @@ final class AppInfoTests: XCTestCase {
     
     let spy = URLOpenSpy()
     installSpy(spy)
-    XCTAssertNoThrow(
-      AppInfo.openUrl(url, inSafari: true),
-      "Should not crash with inSafari option"
-    )
+    let result = AppInfo.openUrl(url, inSafari: true)
+    XCTAssertTrue(result, "Should report success with inSafari option")
     XCTAssertEqual(spy.openedUrls.count, 1, "Should attempt to open one URL")
   }
   
@@ -266,10 +252,8 @@ final class AppInfoTests: XCTestCase {
     
     let spy = URLOpenSpy()
     installSpy(spy)
-    XCTAssertNoThrow(
-      AppInfo.openUrl(url),
-      "Should handle HTTP URLs"
-    )
+    let result = AppInfo.openUrl(url)
+    XCTAssertTrue(result, "Should handle HTTP URLs")
     XCTAssertEqual(spy.openedUrls.first, url, "Should open HTTP URL")
   }
   
@@ -281,10 +265,8 @@ final class AppInfoTests: XCTestCase {
     
     let spy = URLOpenSpy()
     installSpy(spy)
-    XCTAssertNoThrow(
-      AppInfo.openUrl(url),
-      "Should handle HTTPS URLs"
-    )
+    let result = AppInfo.openUrl(url)
+    XCTAssertTrue(result, "Should handle HTTPS URLs")
     XCTAssertEqual(spy.openedUrls.first, url, "Should open HTTPS URL")
   }
   
@@ -296,11 +278,24 @@ final class AppInfoTests: XCTestCase {
     
     let spy = URLOpenSpy()
     installSpy(spy)
-    XCTAssertNoThrow(
-      AppInfo.openUrl(url),
-      "Should handle custom URL schemes"
-    )
+    let result = AppInfo.openUrl(url)
+    XCTAssertTrue(result, "Should handle custom URL schemes")
     XCTAssertEqual(spy.openedUrls.first, url, "Should open custom scheme URL")
+  }
+  
+  func testOpenUrlReturnsFalseWhenSystemCannotOpen() {
+    guard let url = URL(string: "myapp://deeplink") else {
+      XCTFail("Failed to create custom scheme URL")
+      return
+    }
+    
+    let spy = URLOpenSpy()
+    spy.shouldAllowOpening = false
+    installSpy(spy)
+    
+    let result = AppInfo.openUrl(url)
+    XCTAssertFalse(result, "Should report failure when canOpenURL is false")
+    XCTAssertTrue(spy.openedUrls.isEmpty, "Should not invoke opener when cannot open URL")
   }
   
 #if os(iOS)
@@ -309,20 +304,16 @@ final class AppInfoTests: XCTestCase {
   func testOpenSettings() {
     let spy = URLOpenSpy()
     installSpy(spy)
-    XCTAssertNoThrow(
-      AppInfo.openSettings(),
-      "Should not crash when opening settings"
-    )
+    let result = AppInfo.openSettings()
+    XCTAssertTrue(result, "Should report success when opening settings")
     XCTAssertEqual(spy.openedUrls.count, 1, "Should attempt to open settings URL")
   }
   
   func testOpenNotificationSettings() {
     let spy = URLOpenSpy()
     installSpy(spy)
-    XCTAssertNoThrow(
-      AppInfo.openNotificationSettings(),
-      "Should not crash when opening notification settings"
-    )
+    let result = AppInfo.openNotificationSettings()
+    XCTAssertTrue(result, "Should report success when opening notification settings")
     XCTAssertEqual(spy.openedUrls.count, 1, "Should attempt to open notification settings URL")
   }
 #endif
@@ -365,10 +356,8 @@ final class AppInfoTests: XCTestCase {
     installSpy(spy)
     
     for appId in realAppIds {
-      XCTAssertNoThrow(
-        AppInfo.openAppStore(appId: appId),
-        "Should handle real App Store IDs"
-      )
+      let result = AppInfo.openAppStore(appId: appId)
+      XCTAssertTrue(result, "Should handle real App Store IDs")
     }
     XCTAssertEqual(spy.openedUrls.count, realAppIds.count, "Should attempt to open one URL per app ID")
   }

--- a/Tests/Tests/Core/Extensions/Foundation/DateFormatterTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/DateFormatterTests.swift
@@ -142,6 +142,13 @@ final class DateFormatterTests: XCTestCase {
     XCTAssertEqual(result1, result2, "Formatter should produce consistent results")
   }
   
+  func testFormatterAccessReturnsIndependentInstances() {
+    let first = DateFormatter.iso8601Date
+    let second = DateFormatter.iso8601Date
+    
+    XCTAssertFalse(first === second, "Each access should return an independent formatter instance")
+  }
+  
   func testFormattersAreDifferent() {
     // Ensure different formatters produce different output
     let iso = DateFormatter.iso8601Date

--- a/Tests/Tests/Core/Extensions/Foundation/DecodableDictionaryTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/DecodableDictionaryTests.swift
@@ -18,12 +18,21 @@ class DecodableDictionaryTests: XCTestCase {
     do {
       let object = try data?.decode(TestResponse.self, with: JSONDecoder())
       XCTAssertEqual(object?.id, 12)
-      XCTAssertEqual(object?.configuration.dictionary?["name"] as? String, "PovioKit")
-      XCTAssertEqual(object?.configuration.dictionary?["value"] as? Int, 4)
-      XCTAssertEqual((object?.configuration.dictionary?["values"] as? [Int])?.count, 3)
+      XCTAssertEqual(object?.configuration.dictionary["name"] as? String, "PovioKit")
+      XCTAssertEqual(object?.configuration.dictionary["value"] as? Int, 4)
+      XCTAssertEqual((object?.configuration.dictionary["values"] as? [Int])?.count, 3)
     } catch {
       XCTFail("Could not decode TestResponse! \(error)")
     }
+  }
+  
+  func testDecodeThrowsWhenConfigurationIsNotDictionary() {
+    let responseString = """
+    {"id": 12, "configuration": [1,2,3]}
+    """
+    let data = responseString.data(using: .utf8)
+    
+    XCTAssertThrowsError(try data?.decode(TestResponse.self, with: JSONDecoder()))
   }
 }
 

--- a/Tests/Tests/Core/Extensions/Foundation/EncodableTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/EncodableTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import PovioKitCore
 
 class EncodableTests: XCTestCase {
   func testEncode() {
@@ -17,6 +18,14 @@ class EncodableTests: XCTestCase {
       XCTAssertEqual(json["name"] as? String, "PovioKit")
     } catch {
       XCTFail("Could not encode TestRequest!")
+    }
+  }
+  
+  func testEncodeThrowsForTopLevelArray() {
+    let request = [TestRequest(id: 1, name: "PovioKit")]
+    
+    XCTAssertThrowsError(try request.toJSON(with: JSONEncoder())) { error in
+      XCTAssertEqual(error as? EncodableJSONError, .invalidTopLevelObject)
     }
   }
 }

--- a/Tests/Tests/Core/Extensions/Foundation/NotificationCenterTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/NotificationCenterTests.swift
@@ -1,0 +1,79 @@
+//
+//  NotificationCenterTests.swift
+//  PovioKit_Tests
+//
+//  Created by Codex on 15/04/2026.
+//  Copyright © 2026 Povio Inc. All rights reserved.
+//
+
+import Combine
+import XCTest
+import PovioKitCore
+
+final class NotificationCenterTests: XCTestCase {
+  private var cancellables: Set<AnyCancellable> = []
+  
+  override func tearDown() {
+    cancellables.removeAll()
+    super.tearDown()
+  }
+  
+  func testDeviceDidShakeNameMapping() {
+    XCTAssertEqual(
+      AppNotification.deviceDidShake.name.rawValue,
+      "com.poviokit.notification.deviceDidShake"
+    )
+  }
+  
+  func testNamedNotificationNameMapping() {
+    let custom = AppNotification.named("com.poviokit.tests.custom")
+    XCTAssertEqual(custom.name.rawValue, "com.poviokit.tests.custom")
+  }
+  
+  func testObserveAndPost() {
+    let custom = AppNotification.named("com.poviokit.tests.observeAndPost")
+    let expectation = expectation(description: "Observer receives custom notification")
+    
+    let observer = NotificationCenter.observe(custom) { notification in
+      XCTAssertEqual(notification.name.rawValue, custom.name.rawValue)
+      expectation.fulfill()
+    }
+    
+    NotificationCenter.post(custom)
+    wait(for: [expectation], timeout: 1.0)
+    NotificationCenter.remove(observer)
+  }
+  
+  func testObserveMultipleNotifications() {
+    let first = AppNotification.named("com.poviokit.tests.first")
+    let second = AppNotification.named("com.poviokit.tests.second")
+    let expectation = expectation(description: "Observe multiple notifications")
+    expectation.expectedFulfillmentCount = 2
+    
+    let observers = NotificationCenter.observe([first, second]) { notification, _ in
+      if notification.name == first.name || notification.name == second.name {
+        expectation.fulfill()
+      }
+    }
+    
+    NotificationCenter.post(first)
+    NotificationCenter.post(second)
+    wait(for: [expectation], timeout: 1.0)
+    observers.forEach(NotificationCenter.remove)
+  }
+  
+  func testPublisherReceivesPostedNotification() {
+    let custom = AppNotification.named("com.poviokit.tests.publisher")
+    let expectation = expectation(description: "Publisher receives posted notification")
+    
+    NotificationCenter.publisher(for: custom)
+      .sink { notification in
+        XCTAssertEqual(notification.name.rawValue, custom.name.rawValue)
+        expectation.fulfill()
+      }
+      .store(in: &cancellables)
+    
+    NotificationCenter.post(custom)
+    wait(for: [expectation], timeout: 1.0)
+  }
+}

--- a/Tests/Tests/Core/Extensions/Foundation/StringTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/StringTests.swift
@@ -14,11 +14,11 @@ class StringTests: XCTestCase {
     XCTAssertEqual("this-doesn't exist".localized(), "this-doesn't exist")
   }
   
-  func testTrimed() {
-    XCTAssertEqual("  test".trimed, "test")
-    XCTAssertEqual("test  ".trimed, "test")
-    XCTAssertEqual("  test  ".trimed, "test")
-    XCTAssertEqual("\n\n   test  \n\n".trimed, "test")
+  func testTrimmed() {
+    XCTAssertEqual("  test".trimmed, "test")
+    XCTAssertEqual("test  ".trimmed, "test")
+    XCTAssertEqual("  test  ".trimmed, "test")
+    XCTAssertEqual("\n\n   test  \n\n".trimmed, "test")
   }
   
   func testDigits() {

--- a/Tests/Tests/Core/Extensions/Foundation/URLTests.swift
+++ b/Tests/Tests/Core/Extensions/Foundation/URLTests.swift
@@ -26,6 +26,13 @@ class URLTests: XCTestCase {
     XCTAssertNotNil(url)
   }
   
+#if !DEBUG
+  func testInitWithInvalidStringLiteralFallsBackToAboutBlank() {
+    let url = URL(stringLiteral: "https://[::1")
+    XCTAssertEqual(url.absoluteString, "about:blank")
+  }
+#endif
+  
   func testAppending() {
     let url: URL = "https://github.com/poviolabs/PovioKit"
     let newUrl = url


### PR DESCRIPTION
## Summary

This PR hardens and polishes `PovioKitCore` across API safety, error handling, test coverage, and docs.

It focuses on making failure paths explicit, reducing hidden runtime risks, and improving public API/documentation quality while keeping behavior backwards-friendly where possible.

## What Changed

### Safety and API Hardening

- Updated `AppInfo` URL APIs to report operation success:
  - `openSettings() -> Bool`
  - `openNotificationSettings() -> Bool`
  - `openAppStore(appId:) -> Bool`
  - `call(_:) -> Bool`
  - `openUrl(_:inSafari:) -> Bool`
- Removed force-unwrapped Safari URL path and made all open flows return `false` on invalid/unopenable URLs.
- Added phone number sanitization in `AppInfo.call(_:)` before building `tel://` URLs.

### URL Literal Behavior

- Kept `URL` string-literal convenience, but changed invalid-literal behavior:
  - In debug builds: triggers `assertionFailure` (surfaces programmer error early)
  - In non-debug builds: safely falls back to `about:blank` (no production crash)

### JSON Error Handling

- `Encodable.toJSON(with:)` now throws when the encoded top-level JSON is not an object dictionary.
- Added `EncodableJSONError.invalidTopLevelObject` for explicit failure semantics.
- `DecodableDictionary` now throws on invalid shape instead of silently setting `dictionary` to `nil`.
- `DecodableDictionary.dictionary` is now non-optional (`[String: Any]`).

### DateFormatter Thread-Safety

- Replaced shared static formatter instances with computed properties returning a fresh `DateFormatter` each access.
- Moved formatter factory helper to the bottom of the file in a `private extension DateFormatter`.

### Logger

- Removed logger cache and kept direct `os.Logger` creation per call (simpler behavior per review decision).

### Documentation and Polish

- Improved Core docs/wording and API comments:
  - `Sources/Core/PovioKitCore.docc/PovioKitCore.md`
  - `Resources/Core/README.md`
  - multiple Core source comment/doc fixes
- Minor cleanup:
  - fixed stale header in `Result+PovioKit`
  - removed duplicated comment in `Collection+PovioKit`
  - corrected doc examples and grammar issues
  - added `String.trimmed` and deprecated `trimed` with rename guidance

## Breaking / Notable Behavior Changes

- `AppInfo` methods above now return `Bool` (still `@discardableResult` for low-friction usage).
- `DecodableDictionary.dictionary` changed from optional to non-optional.
- `Encodable.toJSON(with:)` is stricter and now throws for non-object top-level JSON.
- Invalid URL string literals now assert in debug builds.